### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/471/421166471.geojson
+++ b/data/421/166/471/421166471.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"UG",
     "wof:created":1459008691,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"41432a061d6da38309ff95afb46627a8",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421166471,
-    "wof:lastmodified":1566595495,
+    "wof:lastmodified":1582350030,
     "wof:name":"Kanungu",
     "wof:parent_id":1092071685,
     "wof:placetype":"locality",

--- a/data/421/173/185/421173185.geojson
+++ b/data/421/173/185/421173185.geojson
@@ -586,6 +586,9 @@
     },
     "wof:country":"UG",
     "wof:created":1459008974,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"499864f295fd2790db41b67af02bb3bd",
     "wof:hierarchy":[
         {
@@ -597,7 +600,7 @@
         }
     ],
     "wof:id":421173185,
-    "wof:lastmodified":1566595497,
+    "wof:lastmodified":1582350030,
     "wof:name":"Kampala",
     "wof:parent_id":1092071203,
     "wof:placetype":"locality",

--- a/data/421/174/009/421174009.geojson
+++ b/data/421/174/009/421174009.geojson
@@ -357,6 +357,9 @@
     },
     "wof:country":"UG",
     "wof:created":1459009017,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1aa55fed2b5d17bc8b5bdb853a872239",
     "wof:hierarchy":[
         {
@@ -367,7 +370,7 @@
         }
     ],
     "wof:id":421174009,
-    "wof:lastmodified":1566595496,
+    "wof:lastmodified":1582350030,
     "wof:name":"Fort Portal Municipality",
     "wof:parent_id":85679939,
     "wof:placetype":"county",

--- a/data/421/174/597/421174597.geojson
+++ b/data/421/174/597/421174597.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"UG",
     "wof:created":1459009037,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b652ca688e2915a1e223f68d9262b27",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421174597,
-    "wof:lastmodified":1566595496,
+    "wof:lastmodified":1582350030,
     "wof:name":"Luwero",
     "wof:parent_id":1092071399,
     "wof:placetype":"locality",

--- a/data/421/202/527/421202527.geojson
+++ b/data/421/202/527/421202527.geojson
@@ -303,6 +303,9 @@
     },
     "wof:country":"UG",
     "wof:created":1459010121,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5a0f52c33b10c36596b4c38b8edbc62",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         }
     ],
     "wof:id":421202527,
-    "wof:lastmodified":1566595495,
+    "wof:lastmodified":1582350030,
     "wof:name":"Kibale",
     "wof:parent_id":85680041,
     "wof:placetype":"county",

--- a/data/856/326/25/85632625.geojson
+++ b/data/856/326/25/85632625.geojson
@@ -896,6 +896,11 @@
     },
     "wof:country":"UG",
     "wof:country_alpha3":"UGA",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"af98a74ab79ce395052383dcdb42296f",
     "wof:hierarchy":[
         {
@@ -912,7 +917,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594925,
+    "wof:lastmodified":1582350019,
     "wof:name":"Uganda",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/797/69/85679769.geojson
+++ b/data/856/797/69/85679769.geojson
@@ -271,6 +271,9 @@
         "wd:id":"Q867219"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e91e471bf19d92b8bd3a8dbddfa94113",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594897,
+    "wof:lastmodified":1582350010,
     "wof:name":"Kalangala",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/73/85679773.geojson
+++ b/data/856/797/73/85679773.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q983748"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3983c7ab3debdec89dfb9894432d89a8",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594897,
+    "wof:lastmodified":1582350011,
     "wof:name":"Jinja",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/77/85679777.geojson
+++ b/data/856/797/77/85679777.geojson
@@ -197,6 +197,9 @@
         "wd:id":"Q1151062"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc8cc3f58b81df208405d42949912b7d",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594898,
+    "wof:lastmodified":1582350011,
     "wof:name":"Kumi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/83/85679783.geojson
+++ b/data/856/797/83/85679783.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q1229906"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c84f836be4598c0bfde9572cf161745",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594898,
+    "wof:lastmodified":1582350011,
     "wof:name":"Kaberamaido",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/87/85679787.geojson
+++ b/data/856/797/87/85679787.geojson
@@ -277,6 +277,9 @@
         "wd:id":"Q1207391"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"205b7197b7a13e5e7623d199471d4c85",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594898,
+    "wof:lastmodified":1582350011,
     "wof:name":"Kayunga",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/89/85679789.geojson
+++ b/data/856/797/89/85679789.geojson
@@ -200,6 +200,9 @@
         "wd:id":"Q1229869"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f94c72828deb3fdf3c295316059f225a",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594897,
+    "wof:lastmodified":1582350010,
     "wof:name":"Iganga",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/95/85679795.geojson
+++ b/data/856/797/95/85679795.geojson
@@ -197,6 +197,9 @@
         "wd:id":"Q164474"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78b20fe7aba47ae6fa8ea60799fdb888",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594897,
+    "wof:lastmodified":1582350010,
     "wof:name":"Kamuli",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/99/85679799.geojson
+++ b/data/856/797/99/85679799.geojson
@@ -268,6 +268,9 @@
         "wd:id":"Q1318822"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d22ae90be41e0cccaa502a1945f584d2",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594898,
+    "wof:lastmodified":1582350011,
     "wof:name":"Amolatar",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/03/85679803.geojson
+++ b/data/856/798/03/85679803.geojson
@@ -266,6 +266,9 @@
         "wd:id":"Q1375859"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"266a370d9b31cec861d48e513d1295f8",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594905,
+    "wof:lastmodified":1582350013,
     "wof:name":"Kaliro",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/07/85679807.geojson
+++ b/data/856/798/07/85679807.geojson
@@ -171,6 +171,9 @@
         "wd:id":"Q6272234"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d0ab3aa8eb1e088fb5c5d112f1864aa",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594908,
+    "wof:lastmodified":1582350014,
     "wof:name":"Namutumba",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/13/85679813.geojson
+++ b/data/856/798/13/85679813.geojson
@@ -196,6 +196,9 @@
         "wd:id":"Q1091337"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1fea5aa661342cada7fca4039343fdb7",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594911,
+    "wof:lastmodified":1582350015,
     "wof:name":"Soroti",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/17/85679817.geojson
+++ b/data/856/798/17/85679817.geojson
@@ -205,6 +205,9 @@
         "wd:id":"Q1151066"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"120ae85dd1f17f709191f4e6cb2a4cfc",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594907,
+    "wof:lastmodified":1582350013,
     "wof:name":"Mukono",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/19/85679819.geojson
+++ b/data/856/798/19/85679819.geojson
@@ -178,6 +178,9 @@
         "wd:id":"Q1375843"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e96674a0ce32051c663413e21edefc92",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594907,
+    "wof:lastmodified":1582350013,
     "wof:name":"Pallisa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/23/85679823.geojson
+++ b/data/856/798/23/85679823.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q976883"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"256e972118aff6d4898270649eb5de2f",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594911,
+    "wof:lastmodified":1582350014,
     "wof:name":"Sembabule",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/27/85679827.geojson
+++ b/data/856/798/27/85679827.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1362109"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14c599b64c5f965b20b6452344e2d93e",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594906,
+    "wof:lastmodified":1582350013,
     "wof:name":"Mpigi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/33/85679833.geojson
+++ b/data/856/798/33/85679833.geojson
@@ -271,6 +271,9 @@
         "wd:id":"Q1229734"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64bcc0635f62cb0f512fe31f9297c15f",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594906,
+    "wof:lastmodified":1582350013,
     "wof:name":"Adjumani",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/37/85679837.geojson
+++ b/data/856/798/37/85679837.geojson
@@ -194,6 +194,9 @@
         "wd:id":"Q1229758"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff1cdcd5c5e99a4a0191220365dda181",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594909,
+    "wof:lastmodified":1582350014,
     "wof:name":"Arua",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/39/85679839.geojson
+++ b/data/856/798/39/85679839.geojson
@@ -274,6 +274,9 @@
         "wd:id":"Q1318857"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"debf200408e600c9d80260d4ece49b8d",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594910,
+    "wof:lastmodified":1582350014,
     "wof:name":"Koboko",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/43/85679843.geojson
+++ b/data/856/798/43/85679843.geojson
@@ -103,6 +103,9 @@
         "wd:id":"Q4996412"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96538f37be47f33b21a731c2fe1aa222",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594908,
+    "wof:lastmodified":1582350014,
     "wof:name":"Buliisa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/49/85679849.geojson
+++ b/data/856/798/49/85679849.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q1375825"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cde3bb4eab4f3815f29e0030a062fc09",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594911,
+    "wof:lastmodified":1582350014,
     "wof:name":"Nebbi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/53/85679853.geojson
+++ b/data/856/798/53/85679853.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q2183668"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85207a935a45f84a62f7118bf892e836",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594909,
+    "wof:lastmodified":1582350014,
     "wof:name":"Moyo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/57/85679857.geojson
+++ b/data/856/798/57/85679857.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q1362587"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f21dc87e1b0337443a0c533ff2b5cb8",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594905,
+    "wof:lastmodified":1582350013,
     "wof:name":"Yumbe",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/61/85679861.geojson
+++ b/data/856/798/61/85679861.geojson
@@ -197,6 +197,9 @@
         "wd:id":"Q1229758"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c12cabe7b8792aba9edb9b78ea0ccc41",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594905,
+    "wof:lastmodified":1582350013,
     "wof:name":"Maracha",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/67/85679867.geojson
+++ b/data/856/798/67/85679867.geojson
@@ -273,6 +273,9 @@
         "wd:id":"Q926417"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a8823db2f27b2f92582452845817c1f",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594906,
+    "wof:lastmodified":1582350013,
     "wof:name":"Kampala",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/71/85679871.geojson
+++ b/data/856/798/71/85679871.geojson
@@ -203,6 +203,9 @@
         "wd:id":"Q892064"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29832455ee249bc32b3fea007e142d31",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594911,
+    "wof:lastmodified":1582350014,
     "wof:name":"Kiboga",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/75/85679875.geojson
+++ b/data/856/798/75/85679875.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q976859"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5a3af373408b51c0e4c88b556772d19",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594907,
+    "wof:lastmodified":1582350013,
     "wof:name":"Nakasongola",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/79/85679879.geojson
+++ b/data/856/798/79/85679879.geojson
@@ -267,6 +267,9 @@
         "wd:id":"Q976848"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5651b81001e6b6eb23a066450c4188d4",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594910,
+    "wof:lastmodified":1582350014,
     "wof:name":"Wakiso",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/81/85679881.geojson
+++ b/data/856/798/81/85679881.geojson
@@ -211,6 +211,9 @@
         "wd:id":"Q1364817"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45eebe58095b593fc56dab8497876747",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594908,
+    "wof:lastmodified":1582350014,
     "wof:name":"Luweero",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/89/85679889.geojson
+++ b/data/856/798/89/85679889.geojson
@@ -268,6 +268,9 @@
         "wd:id":"Q891962"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c5c1de40cb0942937316858cb8368070",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594906,
+    "wof:lastmodified":1582350013,
     "wof:name":"Mubende",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/91/85679891.geojson
+++ b/data/856/798/91/85679891.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1230005"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd1e7d47c511049d1e5fa4d11b0493da",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594908,
+    "wof:lastmodified":1582350014,
     "wof:name":"Mityana",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/95/85679895.geojson
+++ b/data/856/798/95/85679895.geojson
@@ -110,6 +110,9 @@
         "wd:id":"Q3529595"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98c9f8241b782bb07920847932d45fb6",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594905,
+    "wof:lastmodified":1582350013,
     "wof:name":"Nakaseke",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/99/85679899.geojson
+++ b/data/856/798/99/85679899.geojson
@@ -178,6 +178,9 @@
         "wd:id":"Q500162"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c12676cd7b6dd802640d69a92d2ba5b",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594910,
+    "wof:lastmodified":1582350014,
     "wof:name":"Kitgum",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/05/85679905.geojson
+++ b/data/856/799/05/85679905.geojson
@@ -253,6 +253,9 @@
         "wd:id":"Q1028215"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9414e89c89ddba34375777529d2031ee",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594900,
+    "wof:lastmodified":1582350011,
     "wof:name":"Gulu",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/09/85679909.geojson
+++ b/data/856/799/09/85679909.geojson
@@ -256,6 +256,9 @@
         "wd:id":"Q206519"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d9a1fb899919a41e1d2a71c2a14c102",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594903,
+    "wof:lastmodified":1582350012,
     "wof:name":"Lira",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/13/85679913.geojson
+++ b/data/856/799/13/85679913.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1318872"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28238f2d41d3e9ed45c0f1558fcba60b",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594904,
+    "wof:lastmodified":1582350013,
     "wof:name":"Dokolo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/17/85679917.geojson
+++ b/data/856/799/17/85679917.geojson
@@ -137,6 +137,9 @@
         "wd:id":"Q1230035"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7c7fd1281abce178e3db81cec1f5333",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594901,
+    "wof:lastmodified":1582350012,
     "wof:name":"Pader",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/21/85679921.geojson
+++ b/data/856/799/21/85679921.geojson
@@ -212,6 +212,9 @@
         "wd:id":"Q1032238"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa3465d618569fab7d452cbf6b7c1899",
     "wof:hierarchy":[
         {
@@ -229,7 +232,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594902,
+    "wof:lastmodified":1582350012,
     "wof:name":"Masindi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/27/85679927.geojson
+++ b/data/856/799/27/85679927.geojson
@@ -259,6 +259,9 @@
         "wd:id":"Q1318833"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd3cc7628ddda90bafb10e5017b39c13",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594900,
+    "wof:lastmodified":1582350011,
     "wof:name":"Oyam",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/29/85679929.geojson
+++ b/data/856/799/29/85679929.geojson
@@ -263,6 +263,9 @@
         "wd:id":"Q1362129"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9f351e90daf296d06e54cd43f3feb62",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594900,
+    "wof:lastmodified":1582350011,
     "wof:name":"Bundibugyo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/33/85679933.geojson
+++ b/data/856/799/33/85679933.geojson
@@ -274,6 +274,9 @@
         "wd:id":"Q1186535"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b044b68ce7e498e80a826a5a070f7be7",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594900,
+    "wof:lastmodified":1582350011,
     "wof:name":"Hoima",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/39/85679939.geojson
+++ b/data/856/799/39/85679939.geojson
@@ -257,6 +257,9 @@
         "wd:id":"Q1229910"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ce4862f439749319ff88be90b159c5f",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594903,
+    "wof:lastmodified":1582350012,
     "wof:name":"Kabarole",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/43/85679943.geojson
+++ b/data/856/799/43/85679943.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1318815"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"803ff3be9bcfc8e742010f2fa88080d6",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594902,
+    "wof:lastmodified":1582350012,
     "wof:name":"Kyenjojo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/47/85679947.geojson
+++ b/data/856/799/47/85679947.geojson
@@ -257,6 +257,9 @@
         "wd:id":"Q604966"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0fbf09247fc227631c71a0521a1f516",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594904,
+    "wof:lastmodified":1582350012,
     "wof:name":"Kibale",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/51/85679951.geojson
+++ b/data/856/799/51/85679951.geojson
@@ -196,6 +196,9 @@
         "wd:id":"Q1229921"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f229cc45520f77d77e7ab0d0591b527",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594899,
+    "wof:lastmodified":1582350011,
     "wof:name":"Kapchorwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/57/85679957.geojson
+++ b/data/856/799/57/85679957.geojson
@@ -254,6 +254,9 @@
         "wd:id":"Q4987159"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eccb126d306da2e31cf3d1f1e1d60da7",
     "wof:hierarchy":[
         {
@@ -271,7 +274,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594899,
+    "wof:lastmodified":1582350011,
     "wof:name":"Bukwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/61/85679961.geojson
+++ b/data/856/799/61/85679961.geojson
@@ -208,6 +208,9 @@
         "wd:id":"Q1375835"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6432ff07ed13201efabeafd3bc1d4b78",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594898,
+    "wof:lastmodified":1582350011,
     "wof:name":"Sironko",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/65/85679965.geojson
+++ b/data/856/799/65/85679965.geojson
@@ -196,6 +196,9 @@
         "wd:id":"Q581822"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"716c18a7242d5b33427d03c9336292ec",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594903,
+    "wof:lastmodified":1582350012,
     "wof:name":"Mbale",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/69/85679969.geojson
+++ b/data/856/799/69/85679969.geojson
@@ -103,6 +103,9 @@
         "wd:id":"Q6272973"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a996059fd39cb55415a7b5331902b4b8",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594899,
+    "wof:lastmodified":1582350011,
     "wof:name":"Manafwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/75/85679975.geojson
+++ b/data/856/799/75/85679975.geojson
@@ -203,6 +203,9 @@
         "wd:id":"Q1229798"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7110626ce909b2a0d40ba80cdc036791",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594902,
+    "wof:lastmodified":1582350012,
     "wof:name":"Bugiri",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/79/85679979.geojson
+++ b/data/856/799/79/85679979.geojson
@@ -269,6 +269,9 @@
         "wd:id":"Q1229800"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b2aa6d486504fea785a1b86c9f8bbe3",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594903,
+    "wof:lastmodified":1582350012,
     "wof:name":"Busia",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/81/85679981.geojson
+++ b/data/856/799/81/85679981.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q1375755"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fada9e652221eb89411c53f8345bb2da",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594902,
+    "wof:lastmodified":1582350012,
     "wof:name":"Butaleja",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/85/85679985.geojson
+++ b/data/856/799/85/85679985.geojson
@@ -268,6 +268,9 @@
         "wd:id":"Q1364824"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a504cd76f8d70220159853627b4b3e2",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594904,
+    "wof:lastmodified":1582350012,
     "wof:name":"Mayuge",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/89/85679989.geojson
+++ b/data/856/799/89/85679989.geojson
@@ -261,6 +261,9 @@
         "wd:id":"Q1186541"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af3ffbe97c2e438cf002202831b86c3c",
     "wof:hierarchy":[
         {
@@ -278,7 +281,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594901,
+    "wof:lastmodified":1582350012,
     "wof:name":"Tororo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/95/85679995.geojson
+++ b/data/856/799/95/85679995.geojson
@@ -166,6 +166,9 @@
         "wd:id":"Q2544864"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eaa04864a8295e37193bde1bf789910a",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594899,
+    "wof:lastmodified":1582350011,
     "wof:name":"Katakwi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/99/85679999.geojson
+++ b/data/856/799/99/85679999.geojson
@@ -201,6 +201,9 @@
         "wd:id":"Q1318843"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"287d0cfc56cc4bdc2f4ad98f77d46ac7",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594903,
+    "wof:lastmodified":1582350012,
     "wof:name":"Kotido",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/03/85680003.geojson
+++ b/data/856/800/03/85680003.geojson
@@ -179,6 +179,9 @@
         "wd:id":"Q4749005"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eaef45f0b5dec0af2680fbe1af233af6",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594915,
+    "wof:lastmodified":1582350016,
     "wof:name":"Amuria",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/07/85680007.geojson
+++ b/data/856/800/07/85680007.geojson
@@ -107,6 +107,9 @@
         "wd:id":"Q6272909"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e2ebc2c72c67727376407dc2b23652d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594917,
+    "wof:lastmodified":1582350016,
     "wof:name":"Kaabong",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/13/85680013.geojson
+++ b/data/856/800/13/85680013.geojson
@@ -159,6 +159,9 @@
         "wd:id":"Q16249258"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2cc527504526087f2f27a1ee640a9b6e",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594919,
+    "wof:lastmodified":1582350017,
     "wof:name":"Abim",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/17/85680017.geojson
+++ b/data/856/800/17/85680017.geojson
@@ -200,6 +200,9 @@
         "wd:id":"Q1375850"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fe5f9e050cc2f2de18d74ba2b0d32a4",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594917,
+    "wof:lastmodified":1582350016,
     "wof:name":"Moroto",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/21/85680021.geojson
+++ b/data/856/800/21/85680021.geojson
@@ -200,6 +200,9 @@
         "wd:id":"Q1375853"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23732f3f48e38835dda2c23a40cf1cd3",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594917,
+    "wof:lastmodified":1582350016,
     "wof:name":"Nakapiripirit",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/25/85680025.geojson
+++ b/data/856/800/25/85680025.geojson
@@ -258,6 +258,9 @@
         "wd:id":"Q976873"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3d5d4a4c7a921efd27a8d89e0c35727",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594920,
+    "wof:lastmodified":1582350017,
     "wof:name":"Rakai",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/31/85680031.geojson
+++ b/data/856/800/31/85680031.geojson
@@ -200,6 +200,9 @@
         "wd:id":"Q1032233"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95e325fe7e41fe11a0efff33413fb5e6",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594918,
+    "wof:lastmodified":1582350016,
     "wof:name":"Masaka",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/35/85680035.geojson
+++ b/data/856/800/35/85680035.geojson
@@ -253,6 +253,9 @@
         "wd:id":"Q1229797"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"396f70c7aa488e21385d26b4c600b94a",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594915,
+    "wof:lastmodified":1582350016,
     "wof:name":"Bushenyi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/37/85680037.geojson
+++ b/data/856/800/37/85680037.geojson
@@ -255,6 +255,9 @@
         "wd:id":"Q1229919"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c495dfe74be575d24ca9d838a608813f",
     "wof:hierarchy":[
         {
@@ -272,7 +275,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594918,
+    "wof:lastmodified":1582350017,
     "wof:name":"Kasese",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/41/85680041.geojson
+++ b/data/856/800/41/85680041.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1318806"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c636c3b68d147f494234d15a964cb8b3",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594918,
+    "wof:lastmodified":1582350017,
     "wof:name":"Kamwenge",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/47/85680047.geojson
+++ b/data/856/800/47/85680047.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1318877"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e491d047090a35789aeb6869f7abf4fb",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594919,
+    "wof:lastmodified":1582350017,
     "wof:name":"Ibanda",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/51/85680051.geojson
+++ b/data/856/800/51/85680051.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1318887"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2db73d46d5d77584d6477dcd398d3a23",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594916,
+    "wof:lastmodified":1582350016,
     "wof:name":"Isingiro",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/59/85680059.geojson
+++ b/data/856/800/59/85680059.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q204642"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3212aa62b65d68946499e1b97508e29b",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594915,
+    "wof:lastmodified":1582350016,
     "wof:name":"Ntungamo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/61/85680061.geojson
+++ b/data/856/800/61/85680061.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q289419"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9fa580865f2f615134d32a59093890df",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594914,
+    "wof:lastmodified":1582350015,
     "wof:name":"Rukungiri",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/69/85680069.geojson
+++ b/data/856/800/69/85680069.geojson
@@ -176,6 +176,9 @@
         "wd:id":"Q1091595"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9d5855e14c29d4541aa32c8f0ac4c65",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594915,
+    "wof:lastmodified":1582350016,
     "wof:name":"Mbarara",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/73/85680073.geojson
+++ b/data/856/800/73/85680073.geojson
@@ -258,6 +258,9 @@
         "wd:id":"Q3526470"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ff71d469ba223a8926fdf31046d43b5",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594916,
+    "wof:lastmodified":1582350016,
     "wof:name":"Kabale",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/75/85680075.geojson
+++ b/data/856/800/75/85680075.geojson
@@ -186,6 +186,9 @@
         "wd:id":"Q580538"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb66327acf0bae8fc314d4c8e4234fec",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594917,
+    "wof:lastmodified":1582350016,
     "wof:name":"Kisoro",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/79/85680079.geojson
+++ b/data/856/800/79/85680079.geojson
@@ -264,6 +264,9 @@
         "wd:id":"Q1032245"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c4d1a7a70bd410b0564fce17edbf9da",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594918,
+    "wof:lastmodified":1582350017,
     "wof:name":"Kanungu",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/85/85680085.geojson
+++ b/data/856/800/85/85680085.geojson
@@ -341,6 +341,9 @@
         "wd:id":"Q8073799"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b807e983b1cee7625ce2e792ed4cbcb2",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594919,
+    "wof:lastmodified":1582350017,
     "wof:name":"Zombo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/89/85680089.geojson
+++ b/data/856/800/89/85680089.geojson
@@ -156,6 +156,9 @@
         "wd:id":"Q6693037"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad89514cba279897f4cc851e6570349e",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594916,
+    "wof:lastmodified":1582350016,
     "wof:name":"Ngora",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/95/85680095.geojson
+++ b/data/856/800/95/85680095.geojson
@@ -175,6 +175,9 @@
         "wd:id":"Q4986830"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41edd696e8ccf46a6d17db871dbdd223",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594914,
+    "wof:lastmodified":1582350016,
     "wof:name":"Bukedea",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/97/85680097.geojson
+++ b/data/856/800/97/85680097.geojson
@@ -201,6 +201,9 @@
         "wd:id":"Q1229869"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"169be7aa4839dfa4d00018501c4f6ce3",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594918,
+    "wof:lastmodified":1582350017,
     "wof:name":"Luuka",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/03/85680103.geojson
+++ b/data/856/801/03/85680103.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q5003357"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"781d2ef61c154194a0a9fcef38cab88a",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594920,
+    "wof:lastmodified":1582350018,
     "wof:name":"Buyende",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/07/85680107.geojson
+++ b/data/856/801/07/85680107.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1362085"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50f49924f409d83cab0085cae0b51237",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594923,
+    "wof:lastmodified":1582350018,
     "wof:name":"Budaka",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/11/85680111.geojson
+++ b/data/856/801/11/85680111.geojson
@@ -202,6 +202,9 @@
         "wd:id":"Q1375843"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1637c854bbf7df986327874b3d719858",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594921,
+    "wof:lastmodified":1582350018,
     "wof:name":"Kibuku",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/19/85680119.geojson
+++ b/data/856/801/19/85680119.geojson
@@ -106,6 +106,9 @@
         "wd:id":"Q6693290"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f04e76b27fd07367a60d4cb8a3146ee",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594922,
+    "wof:lastmodified":1582350018,
     "wof:name":"Serere",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/21/85680121.geojson
+++ b/data/856/801/21/85680121.geojson
@@ -165,6 +165,9 @@
         "wd:id":"Q4986374"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6beeb48b8b62a31faee2359ba0e40d5",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594922,
+    "wof:lastmodified":1582350018,
     "wof:name":"Buikwe",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/25/85680125.geojson
+++ b/data/856/801/25/85680125.geojson
@@ -208,6 +208,9 @@
         "wd:id":"Q1151066"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3388c7e9fc1632942ac18c97b6e7987b",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594925,
+    "wof:lastmodified":1582350019,
     "wof:name":"Buvuma",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/31/85680131.geojson
+++ b/data/856/801/31/85680131.geojson
@@ -139,6 +139,9 @@
         "unlc:id":"UG-119"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f52bc5b6460a27e9fffdac9240859cf3",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594923,
+    "wof:lastmodified":1582350018,
     "wof:name":"Butambala",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/33/85680133.geojson
+++ b/data/856/801/33/85680133.geojson
@@ -192,6 +192,9 @@
         "wd:id":"Q1011712"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ccf8ef8ff7a90beb85eaa2c08ac403a",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594921,
+    "wof:lastmodified":1582350018,
     "wof:name":"Gomba",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/39/85680139.geojson
+++ b/data/856/801/39/85680139.geojson
@@ -103,6 +103,9 @@
         "wd:id":"Q4749014"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2d1e87c83aaa64fda422f869f5a027e",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594923,
+    "wof:lastmodified":1582350018,
     "wof:name":"Amuru",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/47/85680147.geojson
+++ b/data/856/801/47/85680147.geojson
@@ -200,6 +200,9 @@
         "wd:id":"Q500162"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59aeb9b3a66c1dc737c0869b301064a0",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594924,
+    "wof:lastmodified":1582350019,
     "wof:name":"Lamwo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/51/85680151.geojson
+++ b/data/856/801/51/85680151.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q1229750"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f69409e1b7741e588e413dc268db9b7",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594921,
+    "wof:lastmodified":1582350018,
     "wof:name":"Apac",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/57/85680157.geojson
+++ b/data/856/801/57/85680157.geojson
@@ -167,6 +167,9 @@
         "wd:id":"Q3108824"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00dafb03bfb56289efa1dc0e73d9efbd",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594920,
+    "wof:lastmodified":1582350017,
     "wof:name":"Kole",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/61/85680161.geojson
+++ b/data/856/801/61/85680161.geojson
@@ -169,6 +169,9 @@
         "wd:id":"Q4714068"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc0dc152957de11f30e38ec3a9da9d6f",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594920,
+    "wof:lastmodified":1582350017,
     "wof:name":"Alebtong",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/65/85680165.geojson
+++ b/data/856/801/65/85680165.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q6696899"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03a672bcec6c46b2c07106a7a5f7ec27",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594923,
+    "wof:lastmodified":1582350018,
     "wof:name":"Otuke",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/69/85680169.geojson
+++ b/data/856/801/69/85680169.geojson
@@ -101,6 +101,9 @@
         "wd:id":"Q4690976"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f4a3fa8a0e7c9394e2698daf5cf9406",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594921,
+    "wof:lastmodified":1582350018,
     "wof:name":"Agago",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/75/85680175.geojson
+++ b/data/856/801/75/85680175.geojson
@@ -160,6 +160,9 @@
         "wd:id":"Q6699373"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b81bb81b1a9630979346453b910baf7d",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594922,
+    "wof:lastmodified":1582350018,
     "wof:name":"Kiryandongo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/79/85680179.geojson
+++ b/data/856/801/79/85680179.geojson
@@ -153,6 +153,9 @@
         "wd:id":"Q16896010"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c3a561b6473a6f63f5cf57ac5ed9abf",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594924,
+    "wof:lastmodified":1582350018,
     "wof:name":"Ntoroko",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/83/85680183.geojson
+++ b/data/856/801/83/85680183.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q6450897"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f333f4f7fb8e7492b0884780e68e8c11",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594924,
+    "wof:lastmodified":1582350019,
     "wof:name":"Kyegegwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/87/85680187.geojson
+++ b/data/856/801/87/85680187.geojson
@@ -138,6 +138,9 @@
         "unlc:id":"UG-228"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e22d5c2d9d03e93a9c039ef9a73c527",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594922,
+    "wof:lastmodified":1582350018,
     "wof:name":"Kween",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/95/85680195.geojson
+++ b/data/856/801/95/85680195.geojson
@@ -98,6 +98,9 @@
         "wd:id":"Q4987203"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36f7350cb88f47c1c41ef160a6f25fa4",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594920,
+    "wof:lastmodified":1582350017,
     "wof:name":"Bulambuli",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/01/85680201.geojson
+++ b/data/856/802/01/85680201.geojson
@@ -203,6 +203,9 @@
         "wd:id":"Q1375850"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"808f45ecf4f1add01b69d5ea11801a2f",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594913,
+    "wof:lastmodified":1582350015,
     "wof:name":"Napak",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/09/85680209.geojson
+++ b/data/856/802/09/85680209.geojson
@@ -107,6 +107,9 @@
         "wd:id":"Q4748920"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b29cb28e5ef934fa50fc7245d0ea5b8",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594912,
+    "wof:lastmodified":1582350015,
     "wof:name":"Amudat",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/11/85680211.geojson
+++ b/data/856/802/11/85680211.geojson
@@ -156,6 +156,9 @@
         "wd:id":"Q6687528"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d870782b27983bd52a2d4d5f7b79d8a0",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594912,
+    "wof:lastmodified":1582350015,
     "wof:name":"Lwengo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/15/85680215.geojson
+++ b/data/856/802/15/85680215.geojson
@@ -165,6 +165,9 @@
         "wd:id":"Q6687695"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ebf029e0aee9bdc249f3c8ec9918613",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594914,
+    "wof:lastmodified":1582350015,
     "wof:name":"Lyantonde",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/19/85680219.geojson
+++ b/data/856/802/19/85680219.geojson
@@ -163,6 +163,9 @@
         "wd:id":"Q4986998"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce20a18cb1904ca57223a747634860f3",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594912,
+    "wof:lastmodified":1582350015,
     "wof:name":"Bukomansimbi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/23/85680223.geojson
+++ b/data/856/802/23/85680223.geojson
@@ -339,6 +339,9 @@
         "wd:id":"Q15822537"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d37f8f4c1205466f5d203452f10b69dc",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594914,
+    "wof:lastmodified":1582350015,
     "wof:name":"Kalungu",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/29/85680229.geojson
+++ b/data/856/802/29/85680229.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q6700100"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50ee801a8dfb7fcac561f33e9aba6621",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594912,
+    "wof:lastmodified":1582350015,
     "wof:name":"Rubirizi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/33/85680233.geojson
+++ b/data/856/802/33/85680233.geojson
@@ -162,6 +162,9 @@
         "wd:id":"Q6699878"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"627e1dd6cdc0fe673bff24b9cacd7357",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594912,
+    "wof:lastmodified":1582350015,
     "wof:name":"Mitooma",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/37/85680237.geojson
+++ b/data/856/802/37/85680237.geojson
@@ -145,6 +145,9 @@
         "unlc:id":"UG-425"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb08930c6f5d64f70dd4fe4bd8f1876b",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594913,
+    "wof:lastmodified":1582350015,
     "wof:name":"Sheema",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/41/85680241.geojson
+++ b/data/856/802/41/85680241.geojson
@@ -145,6 +145,9 @@
         "wd:id":"Q4986330"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c37b5433960da6ccb9587750b2299cf",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594913,
+    "wof:lastmodified":1582350015,
     "wof:name":"Buhweju",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/47/85680247.geojson
+++ b/data/856/802/47/85680247.geojson
@@ -197,6 +197,9 @@
         "wd:id":"Q1028215"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60963ecac8503ba349e853c32e7bfab5",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594914,
+    "wof:lastmodified":1582350015,
     "wof:name":"Nwoya",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/51/85680251.geojson
+++ b/data/856/802/51/85680251.geojson
@@ -170,6 +170,9 @@
         "wd:id":"Q4985181"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e7643dc038129083d8d4dc590a90ad0",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566594912,
+    "wof:lastmodified":1582350015,
     "wof:name":"Bududa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/857/718/95/85771895.geojson
+++ b/data/857/718/95/85771895.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Makerere"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"73ccbc29d7ad40b2cdd3e83456e9d693",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379471,
+    "wof:lastmodified":1582350010,
     "wof:name":"Makerere",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/97/85771897.geojson
+++ b/data/857/718/97/85771897.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Mulago"
     },
     "wof:country":"UG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"727ed031e376cb0b395bfc7e9719f0d8",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594897,
+    "wof:lastmodified":1582350010,
     "wof:name":"Mulago",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/433/277/890433277.geojson
+++ b/data/890/433/277/890433277.geojson
@@ -184,6 +184,9 @@
     },
     "wof:country":"UG",
     "wof:created":1469051974,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"bb6489233aad0350acb2a048f9ca1612",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":890433277,
-    "wof:lastmodified":1566595502,
+    "wof:lastmodified":1582350030,
     "wof:name":"Sironko",
     "wof:parent_id":1092068781,
     "wof:placetype":"locality",

--- a/data/890/435/353/890435353.geojson
+++ b/data/890/435/353/890435353.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"UG",
     "wof:created":1469052064,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2d311e14b34f0ef76ff3b3ea9d13428",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":890435353,
-    "wof:lastmodified":1566595503,
+    "wof:lastmodified":1582350030,
     "wof:name":"Kitgum",
     "wof:parent_id":1092070355,
     "wof:placetype":"locality",

--- a/data/890/449/923/890449923.geojson
+++ b/data/890/449/923/890449923.geojson
@@ -247,6 +247,9 @@
     },
     "wof:country":"UG",
     "wof:created":1469052716,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5985560fbc6856fc6b018deb338b41c",
     "wof:hierarchy":[
         {
@@ -258,7 +261,7 @@
         }
     ],
     "wof:id":890449923,
-    "wof:lastmodified":1566595499,
+    "wof:lastmodified":1582350030,
     "wof:name":"Mpigi",
     "wof:parent_id":1092072705,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.