### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/856/798/71/85679871.geojson
+++ b/data/856/798/71/85679871.geojson
@@ -19,11 +19,11 @@
     "label:eng_x_preferred_shortcode":[
         "QO"
     ],
-    "lbl:latitude":1.023445,
-    "lbl:longitude":31.73279,
+    "lbl:latitude":0.863208,
+    "lbl:longitude":31.921619,
     "lbl:min_zoom":8.0,
-    "mps:latitude":0.854137,
-    "mps:longitude":31.942077,
+    "mps:latitude":0.863208,
+    "mps:longitude":31.921619,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:max_zoom":11.0,
@@ -253,7 +253,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877026,
+    "wof:lastmodified":1694320549,
     "wof:name":"Kiboga",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/11/85680211.geojson
+++ b/data/856/802/11/85680211.geojson
@@ -19,11 +19,11 @@
     "label:eng_x_preferred_shortcode":[
         "LE"
     ],
-    "lbl:latitude":-0.424871,
-    "lbl:longitude":31.835346,
+    "lbl:latitude":-0.414928,
+    "lbl:longitude":31.464816,
     "lbl:min_zoom":8.0,
-    "mps:latitude":-0.434865,
-    "mps:longitude":31.4218,
+    "mps:latitude":-0.414928,
+    "mps:longitude":31.464816,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:max_zoom":11.0,
@@ -194,7 +194,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877027,
+    "wof:lastmodified":1694320549,
     "wof:name":"Lwengo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.