### PR TITLE
ug concordances, placetype local, and more

### DIFF
--- a/data/109/206/836/5/1092068365.geojson
+++ b/data/109/206/836/5/1092068365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284323,
-    "geom:area_square_m":3511154128.84523,
+    "geom:area_square_m":3511154312.494285,
     "geom:bbox":"33.012407,2.588645,33.604402,3.307785",
     "geom:latitude":2.912029,
     "geom:longitude":33.345997,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.AG.AO",
         "wd:id":"Q3536053"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899244,
-    "wof:geomhash":"3058bdda324fe8f6ad48d4a55f0daec8",
+    "wof:geomhash":"2bc1ea3483d549cd3e03fc3ceb24f025",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092068365,
-    "wof:lastmodified":1690877058,
+    "wof:lastmodified":1695886803,
     "wof:name":"Agago",
     "wof:parent_id":85680169,
     "wof:placetype":"county",

--- a/data/109/206/839/5/1092068395.geojson
+++ b/data/109/206/839/5/1092068395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111432,
-    "geom:area_square_m":1377034488.83554,
+    "geom:area_square_m":1377034945.91037,
     "geom:bbox":"33.347131,1.727259,33.896328,2.247851",
     "geom:latitude":2.009474,
     "geom:longitude":33.637207,
@@ -205,9 +205,10 @@
         "hasc:id":"UG.AM.AU",
         "wd:id":"Q1375762"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899246,
-    "wof:geomhash":"6722ef11d4533a9cca7c08060c8c82ea",
+    "wof:geomhash":"e3b417038a71e1b8d68d41396601c216",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1092068395,
-    "wof:lastmodified":1690877058,
+    "wof:lastmodified":1695886803,
     "wof:name":"Amuria",
     "wof:parent_id":85680003,
     "wof:placetype":"county",

--- a/data/109/206/843/5/1092068435.geojson
+++ b/data/109/206/843/5/1092068435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189314,
-    "geom:area_square_m":2336463427.384172,
+    "geom:area_square_m":2336463427.38389,
     "geom:bbox":"31.0488417098,3.18105458001,31.5351832344,3.79408",
     "geom:latitude":3.523409,
     "geom:longitude":31.28826,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.YU.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899247,
-    "wof:geomhash":"a81e3d4bd70fb7ce0f9deaea9c109bf7",
+    "wof:geomhash":"8b1e1327b3b6c13a4c3353f6be4f9586",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068435,
-    "wof:lastmodified":1566595457,
+    "wof:lastmodified":1695886710,
     "wof:name":"Aringa",
     "wof:parent_id":85679857,
     "wof:placetype":"county",

--- a/data/109/206/847/5/1092068475.geojson
+++ b/data/109/206/847/5/1092068475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000866,
-    "geom:area_square_m":10692166.963626,
+    "geom:area_square_m":10692086.68998,
     "geom:bbox":"30.898524,3.00259,30.934545,3.039879",
     "geom:latitude":3.020098,
     "geom:longitude":30.915793,
@@ -194,9 +194,10 @@
         "hasc:id":"UG.AX.AU",
         "wd:id":"Q1229758"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899249,
-    "wof:geomhash":"9e6f7aee0f17006b30ab8532b4e1ca87",
+    "wof:geomhash":"d2998bd9c5ad73c869a5ae25be2b0a89",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":1092068475,
-    "wof:lastmodified":1690877058,
+    "wof:lastmodified":1695886710,
     "wof:name":"Arua Municipality",
     "wof:parent_id":85679837,
     "wof:placetype":"county",

--- a/data/109/206/850/3/1092068503.geojson
+++ b/data/109/206/850/3/1092068503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273688,
-    "geom:area_square_m":3379748844.679579,
+    "geom:area_square_m":3379748454.181743,
     "geom:bbox":"32.471596,2.531241,33.223165,3.241764",
     "geom:latitude":2.935463,
     "geom:longitude":32.871562,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.PR.AU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899250,
-    "wof:geomhash":"c3b8a3862fa43e116b871b1bf3ea19e8",
+    "wof:geomhash":"fdf9191bfc79d6412c64a26c24a8a140",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068503,
-    "wof:lastmodified":1627522952,
+    "wof:lastmodified":1695886161,
     "wof:name":"Aruu",
     "wof:parent_id":85679917,
     "wof:placetype":"county",

--- a/data/109/206/854/7/1092068547.geojson
+++ b/data/109/206/854/7/1092068547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147958,
-    "geom:area_square_m":1827041467.086497,
+    "geom:area_square_m":1827041499.630038,
     "geom:bbox":"32.183652,2.771678,32.658128,3.302897",
     "geom:latitude":2.983741,
     "geom:longitude":32.397207,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"UG.GL.AW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899252,
-    "wof:geomhash":"79890bb0da6a10d7b10a32d30473b796",
+    "wof:geomhash":"df1bbd9b169b8418bf8a2cd318a3d5cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092068547,
-    "wof:lastmodified":1627522952,
+    "wof:lastmodified":1695886161,
     "wof:name":"Aswa",
     "wof:parent_id":85679905,
     "wof:placetype":"county",

--- a/data/109/206/859/1/1092068591.geojson
+++ b/data/109/206/859/1/1092068591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031652,
-    "geom:area_square_m":390827743.394073,
+    "geom:area_square_m":390827305.76593,
     "geom:bbox":"30.768817,2.961515,31.113868,3.137582",
     "geom:latitude":3.047134,
     "geom:longitude":30.910968,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AX.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899253,
-    "wof:geomhash":"3cbe5b3af3fdcfec9730238c1b8064d3",
+    "wof:geomhash":"4f59415f86ebe692c9c474e59967a623",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068591,
-    "wof:lastmodified":1627522952,
+    "wof:lastmodified":1695886162,
     "wof:name":"Ayivu",
     "wof:parent_id":85679837,
     "wof:placetype":"county",

--- a/data/109/206/863/3/1092068633.geojson
+++ b/data/109/206/863/3/1092068633.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"UG.LW.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899254,
     "wof:geomhash":"c214f3d2a8b6c31dca03f251cf0bc1f1",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1092068633,
-    "wof:lastmodified":1694639797,
+    "wof:lastmodified":1695886173,
     "wof:name":"Wabusana",
     "wof:parent_id":85679881,
     "wof:placetype":"county",

--- a/data/109/206/867/3/1092068673.geojson
+++ b/data/109/206/867/3/1092068673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095335,
-    "geom:area_square_m":1178606577.788156,
+    "geom:area_square_m":1178606852.992474,
     "geom:bbox":"32.693996,0.779842,32.988372,1.47762",
     "geom:latitude":1.102569,
     "geom:longitude":32.851704,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KY.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899256,
-    "wof:geomhash":"62b633b9bb25cc39cfc6521d721f5170",
+    "wof:geomhash":"e53788710f95afce4203503b4449b620",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1092068673,
-    "wof:lastmodified":1627522952,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bbaale",
     "wof:parent_id":85679787,
     "wof:placetype":"county",

--- a/data/109/206/871/5/1092068715.geojson
+++ b/data/109/206/871/5/1092068715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404667,
-    "geom:area_square_m":4999362749.248236,
+    "geom:area_square_m":4999362885.820486,
     "geom:bbox":"33.630168,1.885623,34.590829,2.907413",
     "geom:latitude":2.399602,
     "geom:longitude":34.221374,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NQ.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899258,
-    "wof:geomhash":"a1ba3770fe39bb1db33b790bb78735ca",
+    "wof:geomhash":"f076aba9da5dd631d22838b65d803c72",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068715,
-    "wof:lastmodified":1627522952,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bokora",
     "wof:parent_id":85680201,
     "wof:placetype":"county",

--- a/data/109/206/875/3/1092068753.geojson
+++ b/data/109/206/875/3/1092068753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049808,
-    "geom:area_square_m":615812699.339592,
+    "geom:area_square_m":615812630.028143,
     "geom:bbox":"34.181888,0.753533,34.492231,1.027696",
     "geom:latitude":0.889976,
     "geom:longitude":34.34159,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MW.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899259,
-    "wof:geomhash":"d5e2ac79b5552ae262aab29f15fa07d0",
+    "wof:geomhash":"6779657075c399e0685cfcc4c0ab2545",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068753,
-    "wof:lastmodified":1627522952,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bubulo",
     "wof:parent_id":85679969,
     "wof:placetype":"county",

--- a/data/109/206/878/1/1092068781.geojson
+++ b/data/109/206/878/1/1092068781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036252,
-    "geom:area_square_m":448172273.789602,
+    "geom:area_square_m":448172201.159421,
     "geom:bbox":"34.17828,1.086904,34.527208,1.289348",
     "geom:latitude":1.172689,
     "geom:longitude":34.331562,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.SK.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899261,
-    "wof:geomhash":"df10d4c5245e176e729cf9988b191095",
+    "wof:geomhash":"69feb1f3b2f7cdaab9a97085e8f3c4b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092068781,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886162,
     "wof:name":"Budadiri",
     "wof:parent_id":85679961,
     "wof:placetype":"county",

--- a/data/109/206/881/7/1092068817.geojson
+++ b/data/109/206/881/7/1092068817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033363,
-    "geom:area_square_m":412470673.63417,
+    "geom:area_square_m":412470673.63412,
     "geom:bbox":"33.86294,0.9375,34.12558,1.193936",
     "geom:latitude":1.062625,
     "geom:longitude":33.987985,
@@ -202,12 +202,13 @@
         "hasc:id":"UG.BD.BU",
         "wd:id":"Q1362085"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85680107
     ],
     "wof:country":"UG",
     "wof:created":1473899262,
-    "wof:geomhash":"c9f468aaec8fa189c193f35a7d81be8f",
+    "wof:geomhash":"c260a72fa64740f407aa9c89dcc3f369",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1092068817,
-    "wof:lastmodified":1690877056,
+    "wof:lastmodified":1695886803,
     "wof:name":"Budaka",
     "wof:parent_id":85680107,
     "wof:placetype":"county",

--- a/data/109/206/885/5/1092068855.geojson
+++ b/data/109/206/885/5/1092068855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15269,
-    "geom:area_square_m":1887582373.689764,
+    "geom:area_square_m":1887582071.041809,
     "geom:bbox":"32.820667,0.987438,33.439334,1.4839",
     "geom:latitude":1.2643,
     "geom:longitude":33.140939,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KX.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899264,
-    "wof:geomhash":"973f35bfa63d3cb30f3fc688d00e8dca",
+    "wof:geomhash":"ba6764b345af5852c22fee6e5e502a3f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1092068855,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886162,
     "wof:name":"Budiope",
     "wof:parent_id":85680103,
     "wof:placetype":"county",

--- a/data/109/206/887/7/1092068877.geojson
+++ b/data/109/206/887/7/1092068877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059293,
-    "geom:area_square_m":733001418.787954,
+    "geom:area_square_m":733001367.289429,
     "geom:bbox":"29.573558,-1.389214,29.821324,-1.007282",
     "geom:latitude":-1.217197,
     "geom:longitude":29.681477,
@@ -128,9 +128,10 @@
         "hasc:id":"UG.KR.BF",
         "wd:id":"Q580538"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899265,
-    "wof:geomhash":"8d354389147b4f37b438fa18ef55afb6",
+    "wof:geomhash":"a5703f473225b09d8ec2e53c9bcaee2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092068877,
-    "wof:lastmodified":1690877056,
+    "wof:lastmodified":1695886710,
     "wof:name":"Bufumbira",
     "wof:parent_id":85680075,
     "wof:placetype":"county",

--- a/data/109/206/891/7/1092068917.geojson
+++ b/data/109/206/891/7/1092068917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093073,
-    "geom:area_square_m":1150682124.532311,
+    "geom:area_square_m":1150682074.365345,
     "geom:bbox":"32.92713,0.790096,33.305464,1.227779",
     "geom:latitude":1.003074,
     "geom:longitude":33.094813,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.QU.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899267,
-    "wof:geomhash":"a830fe0a0c4d43178bb5e4815cfde3b5",
+    "wof:geomhash":"669adc842d8b770f8417f5f963c6eb0b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068917,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bugabula",
     "wof:parent_id":85679795,
     "wof:placetype":"county",

--- a/data/109/206/896/1/1092068961.geojson
+++ b/data/109/206/896/1/1092068961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204809,
-    "geom:area_square_m":2531533395.573807,
+    "geom:area_square_m":2531533048.554633,
     "geom:bbox":"30.791183,1.271169,31.588371,1.85306",
     "geom:latitude":1.579558,
     "geom:longitude":31.21836,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.HO.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899268,
-    "wof:geomhash":"fe883b2f660b0110366c3e3b0b274046",
+    "wof:geomhash":"93850e0da5ae338ad35a2823eb916fad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092068961,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bugahya",
     "wof:parent_id":85679933,
     "wof:placetype":"county",

--- a/data/109/206/899/9/1092068999.geojson
+++ b/data/109/206/899/9/1092068999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135614,
-    "geom:area_square_m":1676645890.183647,
+    "geom:area_square_m":1676646217.810168,
     "geom:bbox":"31.092961,0.70657,31.528013,1.221907",
     "geom:latitude":0.98748,
     "geom:longitude":31.297766,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KI.BZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899269,
-    "wof:geomhash":"d129c50eae1782335f1be952b27eac6f",
+    "wof:geomhash":"2ed405da8833da22179b3317a1f9ed6c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068999,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bugangaizi",
     "wof:parent_id":85679947,
     "wof:placetype":"county",

--- a/data/109/206/903/3/1092069033.geojson
+++ b/data/109/206/903/3/1092069033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030959,
-    "geom:area_square_m":382792954.954327,
+    "geom:area_square_m":382792538.606266,
     "geom:bbox":"33.53855,0.446296,33.684071,0.804612",
     "geom:latitude":0.629582,
     "geom:longitude":33.604845,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.IC.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899271,
-    "wof:geomhash":"b0aade48d9a3d86edb2150510934b574",
+    "wof:geomhash":"76198c018a601bb5df32b0396f008dd5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069033,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bugweri",
     "wof:parent_id":85679789,
     "wof:placetype":"county",

--- a/data/109/206/907/5/1092069075.geojson
+++ b/data/109/206/907/5/1092069075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25517,
-    "geom:area_square_m":3154388946.140862,
+    "geom:area_square_m":3154388978.581704,
     "geom:bbox":"30.540681,1.073639,31.416498,1.560429",
     "geom:latitude":1.316315,
     "geom:longitude":30.942462,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.HO.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899273,
-    "wof:geomhash":"e0b575b40680631fa063b17ec03cba5b",
+    "wof:geomhash":"3ac61155f36f82e6de30440e84defa00",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069075,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886163,
     "wof:name":"Buhaguzi",
     "wof:parent_id":85679933,
     "wof:placetype":"county",

--- a/data/109/206/912/1/1092069121.geojson
+++ b/data/109/206/912/1/1092069121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065101,
-    "geom:area_square_m":804968725.554799,
+    "geom:area_square_m":804969191.114517,
     "geom:bbox":"30.114491,-0.455004,30.517219,-0.187026",
     "geom:latitude":-0.327319,
     "geom:longitude":30.326065,
@@ -190,9 +190,10 @@
         "hasc:id":"UG.BH.BH",
         "wd:id":"Q3537661"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899274,
-    "wof:geomhash":"da78e0fc2dc7c825d7d0844baa1e698b",
+    "wof:geomhash":"35c962bcc002d1861e8aa4a59c068854",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1092069121,
-    "wof:lastmodified":1690877056,
+    "wof:lastmodified":1695886803,
     "wof:name":"Buhweju",
     "wof:parent_id":85680241,
     "wof:placetype":"county",

--- a/data/109/206/914/5/1092069145.geojson
+++ b/data/109/206/914/5/1092069145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117526,
-    "geom:area_square_m":1453211421.719777,
+    "geom:area_square_m":1453211808.989209,
     "geom:bbox":"32.8625,0.050942,33.290897,0.557231",
     "geom:latitude":0.308801,
     "geom:longitude":33.039719,
@@ -191,9 +191,10 @@
         "hasc:id":"UG.BZ.BI",
         "wd:id":"Q3321631"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899276,
-    "wof:geomhash":"532681770b5b821c1a37fd3e2f9fdaef",
+    "wof:geomhash":"e22b32651c5123b13df295a1a990efb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -203,7 +204,7 @@
         }
     ],
     "wof:id":1092069145,
-    "wof:lastmodified":1690877057,
+    "wof:lastmodified":1695886710,
     "wof:name":"Buyikwe",
     "wof:parent_id":85680121,
     "wof:placetype":"county",

--- a/data/109/206/918/5/1092069185.geojson
+++ b/data/109/206/918/5/1092069185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124441,
-    "geom:area_square_m":1538704967.40735,
+    "geom:area_square_m":1538704687.836205,
     "geom:bbox":"31.9925,-0.620338,32.40228,-0.148555",
     "geom:latitude":-0.373378,
     "geom:longitude":32.159913,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KN.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899277,
-    "wof:geomhash":"dcf43929adcaeb6ffef701005af715db",
+    "wof:geomhash":"2a915dee0791c1a26252a87640e6ca1c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092069185,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bujumba",
     "wof:parent_id":85679769,
     "wof:placetype":"county",

--- a/data/109/206/922/3/1092069223.geojson
+++ b/data/109/206/922/3/1092069223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083848,
-    "geom:area_square_m":1036735758.432936,
+    "geom:area_square_m":1036735888.755635,
     "geom:bbox":"29.676543,-0.882286,30.047583,-0.336339",
     "geom:latitude":-0.599154,
     "geom:longitude":29.849482,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KR.BF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899278,
-    "wof:geomhash":"801b95fcaea1e0d79c49419b6a515af8",
+    "wof:geomhash":"d06e79736816d0e3dde6ca38984c45f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1092069223,
-    "wof:lastmodified":1627522953,
+    "wof:lastmodified":1695886163,
     "wof:name":"Rujumbura",
     "wof:parent_id":85680061,
     "wof:placetype":"county",

--- a/data/109/206/926/7/1092069267.geojson
+++ b/data/109/206/926/7/1092069267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120807,
-    "geom:area_square_m":1493629642.789938,
+    "geom:area_square_m":1493629505.23162,
     "geom:bbox":"30.752212,-0.999454,31.270272,-0.667955",
     "geom:latitude":-0.866272,
     "geom:longitude":31.01493,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NG.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899280,
-    "wof:geomhash":"dcb659e1c6353309aa392f590f30dd6a",
+    "wof:geomhash":"be6197f1bff0789fca25526fc1a9c18d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069267,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bukanga",
     "wof:parent_id":85680051,
     "wof:placetype":"county",

--- a/data/109/206/930/7/1092069307.geojson
+++ b/data/109/206/930/7/1092069307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085368,
-    "geom:area_square_m":1055295036.62089,
+    "geom:area_square_m":1055295156.548799,
     "geom:bbox":"33.917256,1.160422,34.274772,1.582569",
     "geom:latitude":1.364517,
     "geom:longitude":34.123377,
@@ -202,9 +202,10 @@
         "hasc:id":"UG.BE.BK",
         "wd:id":"Q1375812"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899282,
-    "wof:geomhash":"2d93b54e6aaba62ffff5812e6e411410",
+    "wof:geomhash":"67a0580bd70f27274b265a7e180fbc19",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":1092069307,
-    "wof:lastmodified":1690877055,
+    "wof:lastmodified":1695886803,
     "wof:name":"Bukedea",
     "wof:parent_id":85680095,
     "wof:placetype":"county",

--- a/data/109/206/932/9/1092069329.geojson
+++ b/data/109/206/932/9/1092069329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04887,
-    "geom:area_square_m":604284400.008141,
+    "geom:area_square_m":604284548.847847,
     "geom:bbox":"31.533323,-0.304324,31.722838,0.052877",
     "geom:latitude":-0.12697,
     "geom:longitude":31.627286,
@@ -196,9 +196,10 @@
         "hasc:id":"UG.BM.BM",
         "wd:id":"Q3321599"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899283,
-    "wof:geomhash":"3a4200529188530fc5561d439f12dc60",
+    "wof:geomhash":"6894199df8922ab67e2fbdfa96f39800",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1092069329,
-    "wof:lastmodified":1690877057,
+    "wof:lastmodified":1695886803,
     "wof:name":"Bukomansimbi",
     "wof:parent_id":85680219,
     "wof:placetype":"county",

--- a/data/109/206/935/7/1092069357.geojson
+++ b/data/109/206/935/7/1092069357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070125,
-    "geom:area_square_m":867112837.211829,
+    "geom:area_square_m":867112416.981167,
     "geom:bbox":"29.704074,-0.203913,30.029155,0.314669",
     "geom:latitude":0.049269,
     "geom:longitude":29.836527,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KS.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899285,
-    "wof:geomhash":"4e69f20078f1b63aba932fcb3435f5a8",
+    "wof:geomhash":"0ff08f350b77c62a9c28f3f4014ead03",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092069357,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bukonjo",
     "wof:parent_id":85680037,
     "wof:placetype":"county",

--- a/data/109/206/939/3/1092069393.geojson
+++ b/data/109/206/939/3/1092069393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256767,
-    "geom:area_square_m":3174855030.480427,
+    "geom:area_square_m":3174854865.617993,
     "geom:bbox":"31.167211,-0.815933,32.060639,-0.1494",
     "geom:latitude":-0.465918,
     "geom:longitude":31.716888,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"UG.LE.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899287,
-    "wof:geomhash":"eab962401f40318ee1427bcfbe68a011",
+    "wof:geomhash":"0713642341b9ed25b0937be175522c44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092069393,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886164,
     "wof:name":"Bukoto",
     "wof:parent_id":85680031,
     "wof:placetype":"county",

--- a/data/109/206/943/5/1092069435.geojson
+++ b/data/109/206/943/5/1092069435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053139,
-    "geom:area_square_m":656879255.314364,
+    "geom:area_square_m":656878802.657206,
     "geom:bbox":"34.226202,1.151863,34.537286,1.569735",
     "geom:latitude":1.381292,
     "geom:longitude":34.352176,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.BB.BL",
         "wd:id":"Q1114868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899288,
-    "wof:geomhash":"91e432f128704122213f2f288d75dded",
+    "wof:geomhash":"53277d428192512cee5a11057594420c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092069435,
-    "wof:lastmodified":1690877058,
+    "wof:lastmodified":1695886803,
     "wof:name":"Bulambuli",
     "wof:parent_id":85680195,
     "wof:placetype":"county",

--- a/data/109/206/948/3/1092069483.geojson
+++ b/data/109/206/948/3/1092069483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070571,
-    "geom:area_square_m":872468603.412932,
+    "geom:area_square_m":872468920.966627,
     "geom:bbox":"33.335299,0.870099,33.636001,1.293475",
     "geom:latitude":1.070524,
     "geom:longitude":33.482625,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RO.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899289,
-    "wof:geomhash":"94be1c979697d02d0998c9a686ac233f",
+    "wof:geomhash":"2e770a7872225c1fa23f3b425bf5e3a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069483,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886164,
     "wof:name":"Bulamogi",
     "wof:parent_id":85679803,
     "wof:placetype":"county",

--- a/data/109/206/951/7/1092069517.geojson
+++ b/data/109/206/951/7/1092069517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.156742,
-    "geom:area_square_m":1937007682.647549,
+    "geom:area_square_m":1937007991.146905,
     "geom:bbox":"31.11393,1.677701,31.612857,2.265025",
     "geom:latitude":1.962317,
     "geom:longitude":31.400864,
@@ -197,9 +197,10 @@
         "hasc:id":"UG.BL.BL",
         "wd:id":"Q1229793"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899291,
-    "wof:geomhash":"3452af9ccb43e82a01d1383c3ecdd7ca",
+    "wof:geomhash":"45445ddee0030b61f56bd0e9a30e49b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":1092069517,
-    "wof:lastmodified":1690877057,
+    "wof:lastmodified":1695886803,
     "wof:name":"Buliisa",
     "wof:parent_id":85679843,
     "wof:placetype":"county",

--- a/data/109/206/956/3/1092069563.geojson
+++ b/data/109/206/956/3/1092069563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040048,
-    "geom:area_square_m":495124175.89776,
+    "geom:area_square_m":495124382.465866,
     "geom:bbox":"34.083465,0.836244,34.336,1.170767",
     "geom:latitude":1.018918,
     "geom:longitude":34.198501,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.ME.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899292,
-    "wof:geomhash":"a7f0438f66f5260b3a67d337212b9cd8",
+    "wof:geomhash":"f265067ec9ad29730fb15e888132a212",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069563,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886164,
     "wof:name":"Bungokho",
     "wof:parent_id":85679965,
     "wof:placetype":"county",

--- a/data/109/206/960/7/1092069607.geojson
+++ b/data/109/206/960/7/1092069607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.278737,
-    "geom:area_square_m":3446520721.934836,
+    "geom:area_square_m":3446520721.93393,
     "geom:bbox":"33.2728545534,-1.0,33.7088081394,0.606885261583",
     "geom:latitude":-0.090174,
     "geom:longitude":33.550692,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MG.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899294,
-    "wof:geomhash":"707a85ecc4a9fa98a8df65db4b29c1ce",
+    "wof:geomhash":"3897b260d7e249f97a5e8be82de8ad51",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092069607,
-    "wof:lastmodified":1566595460,
+    "wof:lastmodified":1695886710,
     "wof:name":"Bunya",
     "wof:parent_id":85679985,
     "wof:placetype":"county",

--- a/data/109/206/963/5/1092069635.geojson
+++ b/data/109/206/963/5/1092069635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040569,
-    "geom:area_square_m":501628200.506513,
+    "geom:area_square_m":501628013.920316,
     "geom:bbox":"29.987005,0.337962,30.294318,0.625575",
     "geom:latitude":0.497603,
     "geom:longitude":30.171855,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BR.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899295,
-    "wof:geomhash":"7f7a3016887f10aec9520cfa0583f1c5",
+    "wof:geomhash":"30c69013706f792dba91bc0898aa2ed5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069635,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886164,
     "wof:name":"Bunyangabu",
     "wof:parent_id":85679939,
     "wof:placetype":"county",

--- a/data/109/206/967/7/1092069677.geojson
+++ b/data/109/206/967/7/1092069677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053154,
-    "geom:area_square_m":657186124.674035,
+    "geom:area_square_m":657185734.584053,
     "geom:bbox":"33.760049,0.688474,34.128163,1.045139",
     "geom:latitude":0.885572,
     "geom:longitude":33.931937,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BJ.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899297,
-    "wof:geomhash":"b36ada9c4ea3f82e5a5108b374abea54",
+    "wof:geomhash":"c627249347e96dddcd9ee7d54d803c0d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1092069677,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886164,
     "wof:name":"Bunyole",
     "wof:parent_id":85679981,
     "wof:placetype":"county",

--- a/data/109/206/972/1/1092069721.geojson
+++ b/data/109/206/972/1/1092069721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10368,
-    "geom:area_square_m":1281935680.265469,
+    "geom:area_square_m":1281935599.746221,
     "geom:bbox":"30.119694,0.268254,30.56079,0.971601",
     "geom:latitude":0.638156,
     "geom:longitude":30.335063,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BR.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899298,
-    "wof:geomhash":"adf79373c605f680013675ac7af53208",
+    "wof:geomhash":"c68835b262d18f329d416f0d879063a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069721,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886164,
     "wof:name":"Burahya",
     "wof:parent_id":85679939,
     "wof:placetype":"county",

--- a/data/109/206/975/9/1092069759.geojson
+++ b/data/109/206/975/9/1092069759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284989,
-    "geom:area_square_m":3522948591.536487,
+    "geom:area_square_m":3522948755.777161,
     "geom:bbox":"31.967119,0.961451,32.79975,1.678684",
     "geom:latitude":1.354819,
     "geom:longitude":32.424491,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NA.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899300,
-    "wof:geomhash":"246405a3fea7d7c9fcdecf73f468e362",
+    "wof:geomhash":"c2d85b9d2e18be070f0a0520248dfd44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1092069759,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886164,
     "wof:name":"Buruli",
     "wof:parent_id":85679875,
     "wof:placetype":"county",

--- a/data/109/206/979/9/1092069799.geojson
+++ b/data/109/206/979/9/1092069799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169124,
-    "geom:area_square_m":2090346890.883288,
+    "geom:area_square_m":2090347102.227244,
     "geom:bbox":"31.605913,1.32623,32.090828,2.056415",
     "geom:latitude":1.675223,
     "geom:longitude":31.804698,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MZ.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899301,
-    "wof:geomhash":"791e58babcbdc55f2d941d8cc03f2443",
+    "wof:geomhash":"15a6ac83f4178705b70b5ad6986ac92f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092069799,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Buruli M",
     "wof:parent_id":85679921,
     "wof:placetype":"county",

--- a/data/109/206/984/9/1092069849.geojson
+++ b/data/109/206/984/9/1092069849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066187,
-    "geom:area_square_m":818319789.671664,
+    "geom:area_square_m":818319844.823926,
     "geom:bbox":"33.53946,0.686461,33.847693,1.09136",
     "geom:latitude":0.87154,
     "geom:longitude":33.680527,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.BK.BS",
         "wd:id":"Q1375819"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899303,
-    "wof:geomhash":"7075a18758a0430304d1a165fd109119",
+    "wof:geomhash":"91770f0c74f7ace72ee4312f0d34a3ce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092069849,
-    "wof:lastmodified":1690877056,
+    "wof:lastmodified":1695886710,
     "wof:name":"Busiki",
     "wof:parent_id":85679807,
     "wof:placetype":"county",

--- a/data/109/206/989/5/1092069895.geojson
+++ b/data/109/206/989/5/1092069895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.20301,
-    "geom:area_square_m":2510239398.231119,
+    "geom:area_square_m":2510239721.465731,
     "geom:bbox":"29.712957,-0.208464,30.296103,0.484098",
     "geom:latitude":0.1452,
     "geom:longitude":30.059183,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KS.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899304,
-    "wof:geomhash":"791d386642dd24cff128afe860c4fb25",
+    "wof:geomhash":"7e590e64614b98709451c3e209a2bdb6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069895,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Busongora",
     "wof:parent_id":85680037,
     "wof:placetype":"county",

--- a/data/109/206/992/9/1092069929.geojson
+++ b/data/109/206/992/9/1092069929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039948,
-    "geom:area_square_m":493953443.077145,
+    "geom:area_square_m":493952997.397634,
     "geom:bbox":"31.802855,0.214137,32.267057,0.393598",
     "geom:latitude":0.306138,
     "geom:longitude":32.039177,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.TY.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899306,
-    "wof:geomhash":"243b2d7e029c3034b8fba24d66f3e3af",
+    "wof:geomhash":"e42f3e37f3599ef459df975ee2ee71c0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092069929,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Busujju",
     "wof:parent_id":85679891,
     "wof:placetype":"county",

--- a/data/109/206/996/9/1092069969.geojson
+++ b/data/109/206/996/9/1092069969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033132,
-    "geom:area_square_m":409681178.49339,
+    "geom:area_square_m":409681495.480619,
     "geom:bbox":"31.810752,0.009841,32.302924,0.319325",
     "geom:latitude":0.156344,
     "geom:longitude":32.073533,
@@ -199,9 +199,10 @@
         "hasc:id":"UG.BT.BT",
         "wd:id":"Q3321622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899307,
-    "wof:geomhash":"5c34c1a913838a66d0a462c7ad80ebae",
+    "wof:geomhash":"02f0ca461172602c8453366817091b1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1092069969,
-    "wof:lastmodified":1690877055,
+    "wof:lastmodified":1695886803,
     "wof:name":"Butambala",
     "wof:parent_id":85680131,
     "wof:placetype":"county",

--- a/data/109/207/001/5/1092070015.geojson
+++ b/data/109/207/001/5/1092070015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02632,
-    "geom:area_square_m":325379468.189972,
+    "geom:area_square_m":325379125.898172,
     "geom:bbox":"33.734858,1.081183,34.138927,1.296434",
     "geom:latitude":1.199027,
     "geom:longitude":33.93754,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.PS.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899308,
-    "wof:geomhash":"131046837fc69b652ba4a8633528b3de",
+    "wof:geomhash":"cd191509034e1c184c60e6d647f8d7c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092070015,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Butebo",
     "wof:parent_id":85679819,
     "wof:placetype":"county",

--- a/data/109/207/005/1/1092070051.geojson
+++ b/data/109/207/005/1/1092070051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02164,
-    "geom:area_square_m":267574174.071684,
+    "geom:area_square_m":267574112.478104,
     "geom:bbox":"33.157844,0.451086,33.37795,0.660143",
     "geom:latitude":0.542961,
     "geom:longitude":33.281268,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.JI.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899310,
-    "wof:geomhash":"c7200ac98f5d5335e12f145d76db09eb",
+    "wof:geomhash":"5c9d78d9ec904ccd76224c71649af5b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070051,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Butembe",
     "wof:parent_id":85679773,
     "wof:placetype":"county",

--- a/data/109/207/009/9/1092070099.geojson
+++ b/data/109/207/009/9/1092070099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.775506,
-    "geom:area_square_m":9588871928.970747,
+    "geom:area_square_m":9588871640.776743,
     "geom:bbox":"32.872383,-1.0,33.522632,0.358205",
     "geom:latitude":-0.3939,
     "geom:longitude":33.207618,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BV.BV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899311,
-    "wof:geomhash":"34a9f9a3e62353962be586c7c24f2a8d",
+    "wof:geomhash":"291c75844edd990d50a8bd411ad6f586",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092070099,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Buvuma Islands",
     "wof:parent_id":85680125,
     "wof:placetype":"county",

--- a/data/109/207/013/7/1092070137.geojson
+++ b/data/109/207/013/7/1092070137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.220176,
-    "geom:area_square_m":2722399544.756038,
+    "geom:area_square_m":2722399763.713203,
     "geom:bbox":"31.021724,0.164263,31.657897,0.868316",
     "geom:latitude":0.506972,
     "geom:longitude":31.378321,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MD.BW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899313,
-    "wof:geomhash":"d2154a66ab99f96928449be197fd12f1",
+    "wof:geomhash":"6c3f9fe7c37c0e62579a201f09bf0e25",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070137,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Buwekula",
     "wof:parent_id":85679889,
     "wof:placetype":"county",

--- a/data/109/207/018/3/1092070183.geojson
+++ b/data/109/207/018/3/1092070183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126707,
-    "geom:area_square_m":1566512880.997423,
+    "geom:area_square_m":1566513334.74416,
     "geom:bbox":"30.535746,0.83875,31.130464,1.203471",
     "geom:latitude":1.017637,
     "geom:longitude":30.808567,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KI.BY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899314,
-    "wof:geomhash":"afa7e5ce5c0ca9acc5068704acc15b81",
+    "wof:geomhash":"b06e3885f6b1d003f950559e613977d6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070183,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886165,
     "wof:name":"Buyaga",
     "wof:parent_id":85679947,
     "wof:placetype":"county",

--- a/data/109/207/020/7/1092070207.geojson
+++ b/data/109/207/020/7/1092070207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094319,
-    "geom:area_square_m":1166152973.689202,
+    "geom:area_square_m":1166153062.640117,
     "geom:bbox":"30.837498,0.634543,31.289133,1.010549",
     "geom:latitude":0.805747,
     "geom:longitude":31.068267,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KI.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899316,
-    "wof:geomhash":"87607e776750122b5a2ebceb33669427",
+    "wof:geomhash":"17fa49db67464eba7847c8dc13ffcf8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092070207,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886166,
     "wof:name":"Buyanja",
     "wof:parent_id":85679947,
     "wof:placetype":"county",

--- a/data/109/207/025/3/1092070253.geojson
+++ b/data/109/207/025/3/1092070253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033489,
-    "geom:area_square_m":414055748.07199,
+    "geom:area_square_m":414055338.258366,
     "geom:bbox":"33.001525,0.657229,33.250445,0.896692",
     "geom:latitude":0.774434,
     "geom:longitude":33.126082,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.QU.BZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899317,
-    "wof:geomhash":"231e9e8fcdb622f05c5b7f015a0229dd",
+    "wof:geomhash":"be4dbac224763447f0f466fcd2688011",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070253,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886166,
     "wof:name":"Buzaaya",
     "wof:parent_id":85679795,
     "wof:placetype":"county",

--- a/data/109/207/028/9/1092070289.geojson
+++ b/data/109/207/028/9/1092070289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022096,
-    "geom:area_square_m":273195031.019818,
+    "geom:area_square_m":273194759.801794,
     "geom:bbox":"29.954837,0.615535,30.114253,0.860451",
     "geom:latitude":0.738229,
     "geom:longitude":30.022897,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BX.BW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899319,
-    "wof:geomhash":"12006f7a2b2704e3206d40733572d7e0",
+    "wof:geomhash":"34ce8d791dedf2346ce7d59011ce379a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070289,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886166,
     "wof:name":"Bwamba",
     "wof:parent_id":85679929,
     "wof:placetype":"county",

--- a/data/109/207/031/9/1092070319.geojson
+++ b/data/109/207/031/9/1092070319.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"UG.NI.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899320,
     "wof:geomhash":"277d740fa56d9b2cb1daed11fc51ff7c",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092070319,
-    "wof:lastmodified":1694639797,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kadani",
     "wof:parent_id":85680021,
     "wof:placetype":"county",

--- a/data/109/207/035/5/1092070355.geojson
+++ b/data/109/207/035/5/1092070355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.321819,
-    "geom:area_square_m":3972316641.535981,
+    "geom:area_square_m":3972316679.217542,
     "geom:bbox":"32.728277,3.118234,33.74179,3.764155",
     "geom:latitude":3.406448,
     "geom:longitude":33.27191,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"UG.QT.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899322,
-    "wof:geomhash":"7b850656fa43c7b135f0f0402271c4c5",
+    "wof:geomhash":"88cb431eaa12555b0094080ae636042f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092070355,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886166,
     "wof:name":"Chua",
     "wof:parent_id":85679899,
     "wof:placetype":"county",

--- a/data/109/207/039/9/1092070399.geojson
+++ b/data/109/207/039/9/1092070399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.580089,
-    "geom:area_square_m":7158626091.393545,
+    "geom:area_square_m":7158626046.063964,
     "geom:bbox":"33.515867,3.0825,34.558862,4.218628",
     "geom:latitude":3.607628,
     "geom:longitude":34.032052,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AB.DD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899323,
-    "wof:geomhash":"ca7532739c99ea99e4470a66ec90ed3d",
+    "wof:geomhash":"7a999699d75b6f641aa37db56ee6dcb0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1092070399,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886166,
     "wof:name":"Dodoth",
     "wof:parent_id":85680007,
     "wof:placetype":"county",

--- a/data/109/207/043/9/1092070439.geojson
+++ b/data/109/207/043/9/1092070439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087389,
-    "geom:area_square_m":1079966403.121695,
+    "geom:area_square_m":1079966403.121692,
     "geom:bbox":"32.860566,1.707964,33.289156,2.111103",
     "geom:latitude":1.939567,
     "geom:longitude":33.077467,
@@ -196,12 +196,13 @@
         "hasc:id":"UG.DO.DK",
         "wd:id":"Q1318872"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85679913
     ],
     "wof:country":"UG",
     "wof:created":1473899325,
-    "wof:geomhash":"f5a05542ecf7d85b13e57031d9f8b988",
+    "wof:geomhash":"626f3958459b1f39db87958c31607da7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1092070439,
-    "wof:lastmodified":1690877051,
+    "wof:lastmodified":1695886802,
     "wof:name":"Dokolo",
     "wof:parent_id":85679913,
     "wof:placetype":"county",

--- a/data/109/207/047/1/1092070471.geojson
+++ b/data/109/207/047/1/1092070471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25157,
-    "geom:area_square_m":3105757069.482615,
+    "geom:area_square_m":3105757069.482581,
     "geom:bbox":"31.400014,2.882042,32.063424,3.592536",
     "geom:latitude":3.228636,
     "geom:longitude":31.76873,
@@ -203,12 +203,13 @@
         "hasc:id":"UG.AD.EA",
         "wd:id":"Q1229734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85679833
     ],
     "wof:country":"UG",
     "wof:created":1473899326,
-    "wof:geomhash":"72f9f331e25a65c113a1307cf361cb9c",
+    "wof:geomhash":"ece950237102d4cadc8b3bc8dc6f03b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":1092070471,
-    "wof:lastmodified":1690877046,
+    "wof:lastmodified":1695886801,
     "wof:name":"Adjumani",
     "wof:parent_id":85679833,
     "wof:placetype":"county",

--- a/data/109/207/052/3/1092070523.geojson
+++ b/data/109/207/052/3/1092070523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019869,
-    "geom:area_square_m":245687534.312363,
+    "geom:area_square_m":245687589.358818,
     "geom:bbox":"32.401463,-0.152046,32.492307,0.106633",
     "geom:latitude":-0.033843,
     "geom:longitude":32.447051,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"UG.WA.ET"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899328,
-    "wof:geomhash":"d2d3f88a6cd523fcfe7518e1071dae38",
+    "wof:geomhash":"c5d8b632a25bc3fc67ea19588acc3cf6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092070523,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886166,
     "wof:name":"Busiro",
     "wof:parent_id":85679879,
     "wof:placetype":"county",

--- a/data/109/207/056/7/1092070567.geojson
+++ b/data/109/207/056/7/1092070567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105293,
-    "geom:area_square_m":1300910950.702804,
+    "geom:area_square_m":1300911027.304924,
     "geom:bbox":"32.779248,2.012566,33.160888,2.654224",
     "geom:latitude":2.304253,
     "geom:longitude":32.969395,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.LL.EU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899329,
-    "wof:geomhash":"8905b7628966d092d2d0ccb282c109d1",
+    "wof:geomhash":"85c94128b7919f57d7673aef3dfa495b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070567,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886167,
     "wof:name":"Erute",
     "wof:parent_id":85679909,
     "wof:placetype":"county",

--- a/data/109/207/058/9/1092070589.geojson
+++ b/data/109/207/058/9/1092070589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13623,
-    "geom:area_square_m":1684496492.753439,
+    "geom:area_square_m":1684496678.731743,
     "geom:bbox":"31.308255,0.03959,32.15463,0.369961",
     "geom:latitude":0.198913,
     "geom:longitude":31.701546,
@@ -199,9 +199,10 @@
         "hasc:id":"UG.GM.GM",
         "wd:id":"Q3321637"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899331,
-    "wof:geomhash":"6caf0df07a915d8a7d07e44d20a1e7b6",
+    "wof:geomhash":"00af1a66876ec7d9617c4e3cf4f74717",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1092070589,
-    "wof:lastmodified":1690877053,
+    "wof:lastmodified":1695886802,
     "wof:name":"Gomba",
     "wof:parent_id":85680133,
     "wof:placetype":"county",

--- a/data/109/207/063/3/1092070633.geojson
+++ b/data/109/207/063/3/1092070633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004224,
-    "geom:area_square_m":52171998.202716,
+    "geom:area_square_m":52171899.894701,
     "geom:bbox":"32.242595,2.739431,32.336097,2.812479",
     "geom:latitude":2.774101,
     "geom:longitude":32.290448,
@@ -191,9 +191,10 @@
         "hasc:id":"UG.GL.GL",
         "wd:id":"Q1028215"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899332,
-    "wof:geomhash":"50648e56146cca09dd3887f8b26296f4",
+    "wof:geomhash":"c7e30c0d06e34eccb81c9ad7759f7ea4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -203,7 +204,7 @@
         }
     ],
     "wof:id":1092070633,
-    "wof:lastmodified":1690877047,
+    "wof:lastmodified":1695886709,
     "wof:name":"Gulu Municipality",
     "wof:parent_id":85679905,
     "wof:placetype":"county",

--- a/data/109/207/067/7/1092070677.geojson
+++ b/data/109/207/067/7/1092070677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078326,
-    "geom:area_square_m":968517471.883643,
+    "geom:area_square_m":968517471.883617,
     "geom:bbox":"30.246556,-0.286396,30.638789,0.164335",
     "geom:latitude":-0.076533,
     "geom:longitude":30.488663,
@@ -199,12 +199,13 @@
         "hasc:id":"UG.IB.IA",
         "wd:id":"Q1318877"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85680047
     ],
     "wof:country":"UG",
     "wof:created":1473899334,
-    "wof:geomhash":"ae302e65195c7b84f82ef486ad30d0f3",
+    "wof:geomhash":"510002b8ac35020c4c4bb36ca147e5a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":1092070677,
-    "wof:lastmodified":1690877053,
+    "wof:lastmodified":1695886802,
     "wof:name":"Ibanda",
     "wof:parent_id":85680047,
     "wof:placetype":"county",

--- a/data/109/207/070/3/1092070703.geojson
+++ b/data/109/207/070/3/1092070703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076908,
-    "geom:area_square_m":950951833.578126,
+    "geom:area_square_m":950951824.843582,
     "geom:bbox":"29.907281,-0.661409,30.311674,-0.301286",
     "geom:latitude":-0.476845,
     "geom:longitude":30.132426,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BC.IG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899335,
-    "wof:geomhash":"3ec155bfad8eefa6830f48ff23788350",
+    "wof:geomhash":"5da6dc886aa4046aa7c35012334ce16e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070703,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886167,
     "wof:name":"Igara",
     "wof:parent_id":85680035,
     "wof:placetype":"county",

--- a/data/109/207/074/1/1092070741.geojson
+++ b/data/109/207/074/1/1092070741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097372,
-    "geom:area_square_m":1203896230.822736,
+    "geom:area_square_m":1203896039.331055,
     "geom:bbox":"30.479261,-1.07618,30.917155,-0.599968",
     "geom:latitude":-0.833985,
     "geom:longitude":30.70411,
@@ -199,9 +199,10 @@
         "hasc:id":"UG.NG.II",
         "wd:id":"Q1318887"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899337,
-    "wof:geomhash":"7529fc3a909538a1899912ae26d68088",
+    "wof:geomhash":"e414c3b971fc71b53afaa94c2982c264",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1092070741,
-    "wof:lastmodified":1690877050,
+    "wof:lastmodified":1695886801,
     "wof:name":"Isingiro",
     "wof:parent_id":85680051,
     "wof:placetype":"county",

--- a/data/109/207/078/1/1092070781.geojson
+++ b/data/109/207/078/1/1092070781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301259,
-    "geom:area_square_m":3719888999.009286,
+    "geom:area_square_m":3719888999.009134,
     "geom:bbox":"33.5478872455,2.6204976503,34.3936427494,3.44184820703",
     "geom:latitude":3.034859,
     "geom:longitude":33.980937,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KF.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899338,
-    "wof:geomhash":"506f5394663e77daca027588de3a3b91",
+    "wof:geomhash":"26c488241395dcee4088f82fbe3e9d2a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092070781,
-    "wof:lastmodified":1566595435,
+    "wof:lastmodified":1695886709,
     "wof:name":"Jie",
     "wof:parent_id":85679999,
     "wof:placetype":"county",

--- a/data/109/207/082/3/1092070823.geojson
+++ b/data/109/207/082/3/1092070823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005277,
-    "geom:area_square_m":65252075.967029,
+    "geom:area_square_m":65252199.74238,
     "geom:bbox":"33.173997,0.393397,33.284158,0.471605",
     "geom:latitude":0.433936,
     "geom:longitude":33.233236,
@@ -197,9 +197,10 @@
         "hasc:id":"UG.JI.JN",
         "wd:id":"Q983748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899340,
-    "wof:geomhash":"56e9ded7dea729074ec3228fcbbef2c7",
+    "wof:geomhash":"c5bdce005185388327b350a2de33f22c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":1092070823,
-    "wof:lastmodified":1690877045,
+    "wof:lastmodified":1695886709,
     "wof:name":"Jinja Municipality",
     "wof:parent_id":85679773,
     "wof:placetype":"county",

--- a/data/109/207/085/7/1092070857.geojson
+++ b/data/109/207/085/7/1092070857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082045,
-    "geom:area_square_m":1013546948.517499,
+    "geom:area_square_m":1013546997.633547,
     "geom:bbox":"31.250821,2.156437,31.528983,2.779689",
     "geom:latitude":2.486527,
     "geom:longitude":31.370917,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NB.JN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899342,
-    "wof:geomhash":"7c6bf9af8adff77a4618bdf99959969d",
+    "wof:geomhash":"4520b9a8b9eec7b94deb9488e56bc0a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092070857,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886167,
     "wof:name":"Jonam",
     "wof:parent_id":85679849,
     "wof:placetype":"county",

--- a/data/109/207/090/5/1092070905.geojson
+++ b/data/109/207/090/5/1092070905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002719,
-    "geom:area_square_m":33616822.951,
+    "geom:area_square_m":33616891.670915,
     "geom:bbox":"29.956605,-1.301961,30.020601,-1.225558",
     "geom:latitude":-1.256607,
     "geom:longitude":29.99004,
@@ -200,9 +200,10 @@
         "hasc:id":"UG.KA.KB",
         "wd:id":"Q3526470"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899343,
-    "wof:geomhash":"73f71ae703eb51278fbffe614bd959d6",
+    "wof:geomhash":"8f59f1d7af7cf861a2dc7c063c35d503",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -212,7 +213,7 @@
         }
     ],
     "wof:id":1092070905,
-    "wof:lastmodified":1690877048,
+    "wof:lastmodified":1695886709,
     "wof:name":"Kabale Municipality",
     "wof:parent_id":85680073,
     "wof:placetype":"county",

--- a/data/109/207/094/1/1092070941.geojson
+++ b/data/109/207/094/1/1092070941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072201,
-    "geom:area_square_m":892389153.196058,
+    "geom:area_square_m":892388990.95334,
     "geom:bbox":"32.945725,1.463323,33.308813,1.913333",
     "geom:latitude":1.696939,
     "geom:longitude":33.127587,
@@ -199,9 +199,10 @@
         "hasc:id":"UG.KD.KB",
         "wd:id":"Q1229906"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899345,
-    "wof:geomhash":"fe17cc9aca30298bf6f98e424565ce7b",
+    "wof:geomhash":"a14fb18c1f324660b1970b6faa2c2a84",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1092070941,
-    "wof:lastmodified":1690877054,
+    "wof:lastmodified":1695886802,
     "wof:name":"Kaberamaido",
     "wof:parent_id":85679783,
     "wof:placetype":"county",

--- a/data/109/207/097/5/1092070975.geojson
+++ b/data/109/207/097/5/1092070975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072258,
-    "geom:area_square_m":893470804.734289,
+    "geom:area_square_m":893470874.972294,
     "geom:bbox":"31.0675,-0.491767,31.3325,-0.026808",
     "geom:latitude":-0.217102,
     "geom:longitude":31.189565,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.LY.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899346,
-    "wof:geomhash":"0b92dda09f399f6c347f6037557a22ca",
+    "wof:geomhash":"9cd3ada9851740fb6d664a433e7ccb0f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092070975,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kabula",
     "wof:parent_id":85680215,
     "wof:placetype":"county",

--- a/data/109/207/101/9/1092071019.geojson
+++ b/data/109/207/101/9/1092071019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0325,
-    "geom:area_square_m":401844991.309615,
+    "geom:area_square_m":401844799.272746,
     "geom:bbox":"33.042154,0.48035,33.296749,0.700314",
     "geom:latitude":0.605454,
     "geom:longitude":33.163621,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.JI.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899348,
-    "wof:geomhash":"c8d92f6f2eda190d0a5b8aac3e4dd182",
+    "wof:geomhash":"3cb60504a50ed69d54564a4816105325",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071019,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kagoma",
     "wof:parent_id":85679773,
     "wof:placetype":"county",

--- a/data/109/207/106/3/1092071063.geojson
+++ b/data/109/207/106/3/1092071063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025426,
-    "geom:area_square_m":314363178.904805,
+    "geom:area_square_m":314363395.046212,
     "geom:bbox":"30.047131,-0.926237,30.233072,-0.725928",
     "geom:latitude":-0.827159,
     "geom:longitude":30.140711,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NT.KJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899349,
-    "wof:geomhash":"706596a6079466d84bf3fc74c5b8cb7d",
+    "wof:geomhash":"15f928cb55215d10cc8b2a68ee846c56",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092071063,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kajara",
     "wof:parent_id":85680059,
     "wof:placetype":"county",

--- a/data/109/207/108/7/1092071087.geojson
+++ b/data/109/207/108/7/1092071087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15031,
-    "geom:area_square_m":1858388687.215585,
+    "geom:area_square_m":1858388380.802655,
     "geom:bbox":"31.202791,-1.001481,31.999626,-0.647624",
     "geom:latitude":-0.892252,
     "geom:longitude":31.620665,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RI.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899351,
-    "wof:geomhash":"6203aa4885f1658f62576558911a9a31",
+    "wof:geomhash":"4c416ab1422ede5f374795f813ee1ac3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071087,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kakuuto",
     "wof:parent_id":85680025,
     "wof:placetype":"county",

--- a/data/109/207/112/7/1092071127.geojson
+++ b/data/109/207/112/7/1092071127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05988,
-    "geom:area_square_m":740044316.239483,
+    "geom:area_square_m":740044577.38895,
     "geom:bbox":"33.208251,1.61184,33.45198,2.055798",
     "geom:latitude":1.837848,
     "geom:longitude":33.335432,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KD.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899352,
-    "wof:geomhash":"397e87833eff66ce02e62c5a6d5d69ce",
+    "wof:geomhash":"6fd7e9d4703c315c08c36c1a69dd52ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092071127,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kalaki",
     "wof:parent_id":85679783,
     "wof:placetype":"county",

--- a/data/109/207/116/7/1092071167.geojson
+++ b/data/109/207/116/7/1092071167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068132,
-    "geom:area_square_m":842460446.517677,
+    "geom:area_square_m":842460135.29731,
     "geom:bbox":"31.647709,-0.274129,31.99159,0.079369",
     "geom:latitude":-0.099669,
     "geom:longitude":31.802012,
@@ -199,9 +199,10 @@
         "hasc:id":"UG.QA.KL",
         "wd:id":"Q3321614"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899354,
-    "wof:geomhash":"80fef33942b701c96c1ab3c5cebda445",
+    "wof:geomhash":"59b55577c924bdffb483291c0eab43e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1092071167,
-    "wof:lastmodified":1690877048,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kalungu",
     "wof:parent_id":85680223,
     "wof:placetype":"county",

--- a/data/109/207/120/3/1092071203.geojson
+++ b/data/109/207/120/3/1092071203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015971,
-    "geom:area_square_m":197478599.520244,
+    "geom:area_square_m":197478598.756182,
     "geom:bbox":"32.510269,0.218872,32.670175,0.408811",
     "geom:latitude":0.317657,
     "geom:longitude":32.596129,
@@ -197,9 +197,10 @@
         "hasc:id":"UG.KM.KM",
         "wd:id":"Q926417"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899355,
-    "wof:geomhash":"fb5b0437ce3ec917ce49beb5d6b21620",
+    "wof:geomhash":"94238dff45823119a67a82119a102f82",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":1092071203,
-    "wof:lastmodified":1690877049,
+    "wof:lastmodified":1695886709,
     "wof:name":"Central Kampala",
     "wof:parent_id":85679867,
     "wof:placetype":"county",

--- a/data/109/207/124/5/1092071245.geojson
+++ b/data/109/207/124/5/1092071245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099014,
-    "geom:area_square_m":1223408223.916869,
+    "geom:area_square_m":1223407846.202668,
     "geom:bbox":"33.494626,1.97563,33.910535,2.417766",
     "geom:latitude":2.216251,
     "geom:longitude":33.741203,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AM.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899357,
-    "wof:geomhash":"0cb4811cfd9adb48fd3bb46905440e8d",
+    "wof:geomhash":"73dfb4e857c35920ad47a1703f0e58c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071245,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kapelebyong",
     "wof:parent_id":85680003,
     "wof:placetype":"county",

--- a/data/109/207/128/7/1092071287.geojson
+++ b/data/109/207/128/7/1092071287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084276,
-    "geom:area_square_m":1042051529.348488,
+    "geom:area_square_m":1042051427.946049,
     "geom:bbox":"30.438334,-0.622901,30.815,-0.210932",
     "geom:latitude":-0.458768,
     "geom:longitude":30.604883,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RR.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899358,
-    "wof:geomhash":"e9f52b6a6556ef14a82b98c7c66f6345",
+    "wof:geomhash":"733e2870470df3f15aa626f2529c68f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071287,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kashari",
     "wof:parent_id":85680069,
     "wof:placetype":"county",

--- a/data/109/207/133/3/1092071333.geojson
+++ b/data/109/207/133/3/1092071333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092625,
-    "geom:area_square_m":1144931699.511924,
+    "geom:area_square_m":1144932052.990868,
     "geom:bbox":"33.015309,1.336463,33.453684,1.676041",
     "geom:latitude":1.490014,
     "geom:longitude":33.255752,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.SX.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899360,
-    "wof:geomhash":"faf69bc4aa160dda7891c5ed96446a42",
+    "wof:geomhash":"f807857fe903902678b991d245aafcdc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071333,
-    "wof:lastmodified":1627522957,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kasilo",
     "wof:parent_id":85680119,
     "wof:placetype":"county",

--- a/data/109/207/135/7/1092071357.geojson
+++ b/data/109/207/135/7/1092071357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155231,
-    "geom:area_square_m":1919368670.291289,
+    "geom:area_square_m":1919368891.278924,
     "geom:bbox":"31.565876,0.242507,31.956955,0.823389",
     "geom:latitude":0.542268,
     "geom:longitude":31.754004,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MD.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899361,
-    "wof:geomhash":"3756e6594d7a48b7645f2ad1a1d0c42d",
+    "wof:geomhash":"429efb20bfe3521dd43130862c6a1c5a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092071357,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kassanda",
     "wof:parent_id":85679889,
     "wof:placetype":"county",

--- a/data/109/207/139/9/1092071399.geojson
+++ b/data/109/207/139/9/1092071399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082481,
-    "geom:area_square_m":1019789722.819188,
+    "geom:area_square_m":1019789709.348886,
     "geom:bbox":"32.317635,0.551348,32.61867,1.138047",
     "geom:latitude":0.813102,
     "geom:longitude":32.476603,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"UG.LW.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899362,
-    "wof:geomhash":"4f1babdbe51ea0593ceb822e15831acd",
+    "wof:geomhash":"9764f69d6c8897a9d03cb076bbb0077e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1092071399,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886168,
     "wof:name":"Katikamu",
     "wof:parent_id":85679881,
     "wof:placetype":"county",

--- a/data/109/207/144/1/1092071441.geojson
+++ b/data/109/207/144/1/1092071441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001075,
-    "geom:area_square_m":13291461.851788,
+    "geom:area_square_m":13291502.949066,
     "geom:bbox":"32.553965,0.982636,32.585689,1.042474",
     "geom:latitude":1.011478,
     "geom:longitude":32.56935,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.LW.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899364,
-    "wof:geomhash":"8f51c0f6c189e8960b67ff3679a75a94",
+    "wof:geomhash":"85a060fe79c6913afb80ec3d04801de7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071441,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886168,
     "wof:name":"Katikamu",
     "wof:parent_id":85679881,
     "wof:placetype":"county",

--- a/data/109/207/147/3/1092071473.geojson
+++ b/data/109/207/147/3/1092071473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126629,
-    "geom:area_square_m":1565786061.56276,
+    "geom:area_square_m":1565785752.769472,
     "geom:bbox":"30.5675,-0.161354,31.055354,0.213906",
     "geom:latitude":0.04417,
     "geom:longitude":30.791651,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KH.KZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899365,
-    "wof:geomhash":"792eb8358b4f8b77af4fbeba24021daa",
+    "wof:geomhash":"76b8a6ff452e21b9bf9de3302c6ce92d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092071473,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kazo",
     "wof:parent_id":1108808411,
     "wof:placetype":"county",

--- a/data/109/207/151/3/1092071513.geojson
+++ b/data/109/207/151/3/1092071513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.294974,
-    "geom:area_square_m":3645114091.966056,
+    "geom:area_square_m":3645114085.801593,
     "geom:bbox":"31.745,1.615876,32.363027,2.369175",
     "geom:latitude":2.02597,
     "geom:longitude":32.040112,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.QD.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899367,
-    "wof:geomhash":"3a905cdeff53c9ba79ef5fb011f0aa01",
+    "wof:geomhash":"d9aa8e38dbe9aea8e4008dd06c491592",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071513,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kibanda",
     "wof:parent_id":85680175,
     "wof:placetype":"county",

--- a/data/109/207/154/3/1092071543.geojson
+++ b/data/109/207/154/3/1092071543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.328145,
-    "geom:area_square_m":4056922459.064831,
+    "geom:area_square_m":4056922246.005953,
     "geom:bbox":"31.293081,0.616175,32.212294,1.368766",
     "geom:latitude":1.014479,
     "geom:longitude":31.763743,
@@ -204,9 +204,10 @@
         "hasc:id":"UG.KG.KB",
         "wd:id":"Q892064"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899368,
-    "wof:geomhash":"cb13ebfd047aaf234a91a000ee6e5adf",
+    "wof:geomhash":"783c28b569fe616f6948902617764b72",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -216,7 +217,7 @@
         }
     ],
     "wof:id":1092071543,
-    "wof:lastmodified":1690877049,
+    "wof:lastmodified":1695886802,
     "wof:name":"Kiboga",
     "wof:parent_id":1108808409,
     "wof:placetype":"county",

--- a/data/109/207/158/5/1092071585.geojson
+++ b/data/109/207/158/5/1092071585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039869,
-    "geom:area_square_m":492902620.65684,
+    "geom:area_square_m":492902403.393272,
     "geom:bbox":"33.626366,0.945987,33.935964,1.172168",
     "geom:latitude":1.056519,
     "geom:longitude":33.800399,
@@ -196,9 +196,10 @@
         "hasc:id":"UG.QB.KB",
         "wd:id":"Q1114885"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899370,
-    "wof:geomhash":"9b3129cf199315762d170c4096405530",
+    "wof:geomhash":"e1bf6ea50f688cb5fe0123ee86c611a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1092071585,
-    "wof:lastmodified":1690877044,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kibuku",
     "wof:parent_id":85680111,
     "wof:placetype":"county",

--- a/data/109/207/160/3/1092071603.geojson
+++ b/data/109/207/160/3/1092071603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051981,
-    "geom:area_square_m":642704125.239847,
+    "geom:area_square_m":642704171.153265,
     "geom:bbox":"33.361537,0.533279,33.578763,0.911201",
     "geom:latitude":0.729659,
     "geom:longitude":33.477848,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.IC.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899371,
-    "wof:geomhash":"53e717e9cb7d546b22ab14e0dbfed637",
+    "wof:geomhash":"125e1bb05e5a09f41bbf54ca4ed6bcf4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071603,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kigulu",
     "wof:parent_id":85679789,
     "wof:placetype":"county",

--- a/data/109/207/164/3/1092071643.geojson
+++ b/data/109/207/164/3/1092071643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.294599,
-    "geom:area_square_m":3637577708.723544,
+    "geom:area_square_m":3637578007.792194,
     "geom:bbox":"31.35942,2.678124,32.363439,3.587165",
     "geom:latitude":3.052668,
     "geom:longitude":31.972441,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AY.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899373,
-    "wof:geomhash":"a72632f70e46498de915dc768b7c2842",
+    "wof:geomhash":"681b12fedec9dff3e769578f225b21ce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071643,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kilak",
     "wof:parent_id":85680139,
     "wof:placetype":"county",

--- a/data/109/207/168/5/1092071685.geojson
+++ b/data/109/207/168/5/1092071685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106626,
-    "geom:area_square_m":1318314176.814352,
+    "geom:area_square_m":1318313375.366724,
     "geom:bbox":"29.581914,-1.07624,29.90249,-0.34019",
     "geom:latitude":-0.808943,
     "geom:longitude":29.726351,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.UU.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899374,
-    "wof:geomhash":"4052609290905634823bba8b3bd3d6e7",
+    "wof:geomhash":"11a7fc21e7a375519c00fcac3faac057",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092071685,
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695886169,
     "wof:name":"Kinkiizi",
     "wof:parent_id":85680079,
     "wof:placetype":"county",

--- a/data/109/207/171/9/1092071719.geojson
+++ b/data/109/207/171/9/1092071719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142972,
-    "geom:area_square_m":1767165246.972468,
+    "geom:area_square_m":1767165412.505271,
     "geom:bbox":"32.314389,1.438016,32.999266,1.839348",
     "geom:latitude":1.622029,
     "geom:longitude":32.73803,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AT.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899376,
-    "wof:geomhash":"3dcf3ecc605fbcb78f6f6e56a3bf2545",
+    "wof:geomhash":"28b480600ea7562377c30564b93e0c8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092071719,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886169,
     "wof:name":"Kyoga",
     "wof:parent_id":85679799,
     "wof:placetype":"county",

--- a/data/109/207/175/9/1092071759.geojson
+++ b/data/109/207/175/9/1092071759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050564,
-    "geom:area_square_m":625235645.44401,
+    "geom:area_square_m":625236128.623965,
     "geom:bbox":"30.212436,-0.180958,30.477558,0.166189",
     "geom:latitude":-0.003127,
     "geom:longitude":30.347907,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KE.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899377,
-    "wof:geomhash":"842f03085bdb3e3012110b289b9377a5",
+    "wof:geomhash":"aada7a44ce39a469a39ab8bdedfba2d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071759,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886169,
     "wof:name":"Kitagwenda",
     "wof:parent_id":85680041,
     "wof:placetype":"county",

--- a/data/109/207/179/5/1092071795.geojson
+++ b/data/109/207/179/5/1092071795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060836,
-    "geom:area_square_m":750828238.912328,
+    "geom:area_square_m":750828238.911726,
     "geom:bbox":"30.848079,3.328859,31.099522,3.744319",
     "geom:latitude":3.52682,
     "geom:longitude":31.006857,
@@ -202,12 +202,13 @@
         "hasc:id":"UG.OK.KB",
         "wd:id":"Q1318857"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85679839
     ],
     "wof:country":"UG",
     "wof:created":1473899378,
-    "wof:geomhash":"3f3f2f69433b9878263a72b661b11d7d",
+    "wof:geomhash":"3f5a31be38250e5fdf1f83cd9e4a96bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1092071795,
-    "wof:lastmodified":1690877054,
+    "wof:lastmodified":1695886802,
     "wof:name":"Koboko",
     "wof:parent_id":85679839,
     "wof:placetype":"county",

--- a/data/109/207/183/7/1092071837.geojson
+++ b/data/109/207/183/7/1092071837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087183,
-    "geom:area_square_m":1077170487.766553,
+    "geom:area_square_m":1077170338.850291,
     "geom:bbox":"32.577029,2.081672,32.92423,2.52221",
     "geom:latitude":2.29551,
     "geom:longitude":32.766649,
@@ -190,9 +190,10 @@
         "hasc:id":"UG.QL.KL",
         "wd:id":"Q3539151"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899380,
-    "wof:geomhash":"8197a001a3e4eb71d4ce5a7aa28d4dad",
+    "wof:geomhash":"6f1a57ec2c21c2c22ec27b256b2a0f6d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1092071837,
-    "wof:lastmodified":1690877054,
+    "wof:lastmodified":1695886802,
     "wof:name":"Kole",
     "wof:parent_id":85680157,
     "wof:placetype":"county",

--- a/data/109/207/186/1/1092071861.geojson
+++ b/data/109/207/186/1/1092071861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043696,
-    "geom:area_square_m":540182272.434596,
+    "geom:area_square_m":540182004.310255,
     "geom:bbox":"34.551741,1.104697,34.831583,1.410567",
     "geom:latitude":1.272786,
     "geom:longitude":34.683352,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BW.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899382,
-    "wof:geomhash":"b202c718e04a9ef11be54c6b2cd58b98",
+    "wof:geomhash":"d0c1bb04b9bb822c1f7a83d6885eeae7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071861,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886169,
     "wof:name":"Kongasis",
     "wof:parent_id":85679957,
     "wof:placetype":"county",

--- a/data/109/207/189/7/1092071897.geojson
+++ b/data/109/207/189/7/1092071897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103676,
-    "geom:area_square_m":1281890968.553733,
+    "geom:area_square_m":1281891252.31267,
     "geom:bbox":"31.09011,-0.921978,31.517846,-0.451803",
     "geom:latitude":-0.66419,
     "geom:longitude":31.28804,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RI.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899383,
-    "wof:geomhash":"f47d9f3f8ea7f73acb1cab45f8285b77",
+    "wof:geomhash":"50e64af0dec2a07a2f5d73ec2c80028c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071897,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886169,
     "wof:name":"Kooki",
     "wof:parent_id":85680025,
     "wof:placetype":"county",

--- a/data/109/207/193/7/1092071937.geojson
+++ b/data/109/207/193/7/1092071937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087309,
-    "geom:area_square_m":1079227339.189071,
+    "geom:area_square_m":1079227339.189131,
     "geom:bbox":"33.729819,1.260694,34.230064,1.6525",
     "geom:latitude":1.476344,
     "geom:longitude":33.96055,
@@ -202,12 +202,13 @@
         "hasc:id":"UG.QM.KM",
         "wd:id":"Q1151062"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85679777
     ],
     "wof:country":"UG",
     "wof:created":1473899384,
-    "wof:geomhash":"de969ed54b0b5d1f7b9298ba0e637830",
+    "wof:geomhash":"2e552f0e087a253448d2930b81a459e4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1092071937,
-    "wof:lastmodified":1690877045,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kumi",
     "wof:parent_id":85679777,
     "wof:placetype":"county",

--- a/data/109/207/197/1/1092071971.geojson
+++ b/data/109/207/197/1/1092071971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116936,
-    "geom:area_square_m":1445128092.609677,
+    "geom:area_square_m":1445127659.891538,
     "geom:bbox":"32.526998,1.622036,32.958544,2.15326",
     "geom:latitude":1.916815,
     "geom:longitude":32.733296,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AQ.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899386,
-    "wof:geomhash":"d22fc3738f463079a8bc626e269c8409",
+    "wof:geomhash":"f09b6babd38bc3bf9b1b63d5d2ffc1cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092071971,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886169,
     "wof:name":"Kwania",
     "wof:parent_id":85680151,
     "wof:placetype":"county",

--- a/data/109/207/200/9/1092072009.geojson
+++ b/data/109/207/200/9/1092072009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069256,
-    "geom:area_square_m":856100285.728967,
+    "geom:area_square_m":856100620.365945,
     "geom:bbox":"34.406713,1.099311,34.756701,1.6025",
     "geom:latitude":1.431976,
     "geom:longitude":34.573335,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.QW.KW",
         "wd:id":"Q3321998"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899387,
-    "wof:geomhash":"7a30de2330dfeb52a9a98f0e0af7c664",
+    "wof:geomhash":"6a6bdf1c3bef221d273b2f6103719142",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092072009,
-    "wof:lastmodified":1690877051,
+    "wof:lastmodified":1695886802,
     "wof:name":"Kween",
     "wof:parent_id":85680187,
     "wof:placetype":"county",

--- a/data/109/207/204/1/1092072041.geojson
+++ b/data/109/207/204/1/1092072041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040185,
-    "geom:area_square_m":496876240.139425,
+    "geom:area_square_m":496876002.626323,
     "geom:bbox":"32.421951,0.280712,32.687578,0.585758",
     "geom:latitude":0.471797,
     "geom:longitude":32.572818,
@@ -187,9 +187,10 @@
         "hasc:id":"UG.WA.KA",
         "wd:id":"Q983748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899389,
-    "wof:geomhash":"54c4fda43c2d76eef036a0fa315fe59c",
+    "wof:geomhash":"295033891cc8179035eb16f97f2e6920",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":1092072041,
-    "wof:lastmodified":1690877047,
+    "wof:lastmodified":1695886709,
     "wof:name":"Kyadondo",
     "wof:parent_id":85679879,
     "wof:placetype":"county",

--- a/data/109/207/207/7/1092072077.geojson
+++ b/data/109/207/207/7/1092072077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00655,
-    "geom:area_square_m":80987570.749782,
+    "geom:area_square_m":80987478.259732,
     "geom:bbox":"32.531579,0.169202,32.633275,0.282872",
     "geom:latitude":0.227811,
     "geom:longitude":32.581437,
@@ -197,9 +197,10 @@
         "hasc:id":"UG.WA.KA",
         "wd:id":"Q983748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899390,
-    "wof:geomhash":"e3f26cef43d6a15dbc193506cadd8442",
+    "wof:geomhash":"23150dac0c71513458c9848030ecf251",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":1092072077,
-    "wof:lastmodified":1690877052,
+    "wof:lastmodified":1695886709,
     "wof:name":"Kyadondo",
     "wof:parent_id":85679879,
     "wof:placetype":"county",

--- a/data/109/207/211/3/1092072113.geojson
+++ b/data/109/207/211/3/1092072113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14196,
-    "geom:area_square_m":1755300069.047555,
+    "geom:area_square_m":1755299437.22859,
     "geom:bbox":"30.769549,0.194327,31.2575,0.770878",
     "geom:latitude":0.453613,
     "geom:longitude":31.001247,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"UG.QG.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899392,
-    "wof:geomhash":"1f95dc9768a4350cbfc4ad267f952829",
+    "wof:geomhash":"a0a9bd32695d77e519f245c52bc6d63e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092072113,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886170,
     "wof:name":"Kyaka",
     "wof:parent_id":85680183,
     "wof:placetype":"county",

--- a/data/109/207/214/9/1092072149.geojson
+++ b/data/109/207/214/9/1092072149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.507845,
-    "geom:area_square_m":6279167570.799254,
+    "geom:area_square_m":6279167810.578534,
     "geom:bbox":"31.997021,-1.0,32.754561,-0.147358",
     "geom:latitude":-0.627921,
     "geom:longitude":32.431007,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KN.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899393,
-    "wof:geomhash":"ec97d10db9ec1efbace4191b45c8bd5b",
+    "wof:geomhash":"499930b1eaecdd83f8a222e5dacbe132",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092072149,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886170,
     "wof:name":"Kyamuswa",
     "wof:parent_id":85679769,
     "wof:placetype":"county",

--- a/data/109/207/218/7/1092072187.geojson
+++ b/data/109/207/218/7/1092072187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076043,
-    "geom:area_square_m":940219525.713364,
+    "geom:area_square_m":940220138.990183,
     "geom:bbox":"31.4375,-0.826294,31.956598,-0.427443",
     "geom:latitude":-0.651882,
     "geom:longitude":31.634076,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RI.KY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899395,
-    "wof:geomhash":"e8c4f005a7a409e2313e486745428ba6",
+    "wof:geomhash":"145f6d62201a95e3beddfe25d715e13a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092072187,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886170,
     "wof:name":"Kyotera",
     "wof:parent_id":85680025,
     "wof:placetype":"county",

--- a/data/109/207/221/5/1092072215.geojson
+++ b/data/109/207/221/5/1092072215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191688,
-    "geom:area_square_m":2367524190.822859,
+    "geom:area_square_m":2367524074.025268,
     "geom:bbox":"33.521563,2.456144,34.036864,3.152992",
     "geom:latitude":2.750613,
     "geom:longitude":33.72987,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AI.LB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899396,
-    "wof:geomhash":"678991fc0cc5dc1e17d83789ee7bc617",
+    "wof:geomhash":"0ca6c202d092a53ed7f0ad9e44d3667e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072215,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886170,
     "wof:name":"Labwor",
     "wof:parent_id":85680013,
     "wof:placetype":"county",

--- a/data/109/207/234/1/1092072341.geojson
+++ b/data/109/207/234/1/1092072341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451029,
-    "geom:area_square_m":5566369309.670201,
+    "geom:area_square_m":5566368819.335387,
     "geom:bbox":"32.196063,3.154338,33.328949,3.890723",
     "geom:latitude":3.545778,
     "geom:longitude":32.728544,
@@ -190,9 +190,10 @@
         "hasc:id":"UG.LM.LM",
         "wd:id":"Q3539277"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899398,
-    "wof:geomhash":"86b7cdb61181b0c440ffcdf8b28d24bb",
+    "wof:geomhash":"b63823184eecedc495160c19aeb5b6d5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1092072341,
-    "wof:lastmodified":1690877048,
+    "wof:lastmodified":1695886801,
     "wof:name":"Lamwo",
     "wof:parent_id":85680147,
     "wof:placetype":"county",

--- a/data/109/207/238/7/1092072387.geojson
+++ b/data/109/207/238/7/1092072387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002856,
-    "geom:area_square_m":35288971.478756,
+    "geom:area_square_m":35289053.486542,
     "geom:bbox":"32.863276,2.217757,32.9275,2.280466",
     "geom:latitude":2.249987,
     "geom:longitude":32.899096,
@@ -197,9 +197,10 @@
         "hasc:id":"UG.LL.LR",
         "wd:id":"Q206519"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899405,
-    "wof:geomhash":"de64f4aa0dcadfaa00e7f35b5d1cde23",
+    "wof:geomhash":"8886f84473e256b4a39ecfce762b7e2d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":1092072387,
-    "wof:lastmodified":1690877052,
+    "wof:lastmodified":1695886709,
     "wof:name":"Lira Municipality",
     "wof:parent_id":85679909,
     "wof:placetype":"county",

--- a/data/109/207/240/3/1092072403.geojson
+++ b/data/109/207/240/3/1092072403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052787,
-    "geom:area_square_m":652654532.712529,
+    "geom:area_square_m":652654497.540409,
     "geom:bbox":"33.21807,0.563123,33.432286,1.078908",
     "geom:latitude":0.807275,
     "geom:longitude":33.337687,
@@ -196,9 +196,10 @@
         "hasc:id":"UG.LK.LU",
         "wd:id":"Q1114977"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899406,
-    "wof:geomhash":"8fa8616ffaa3bbde6aad5ce16eb8776b",
+    "wof:geomhash":"6a085babcf73b8990cf587cf8ddf66ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1092072403,
-    "wof:lastmodified":1690877051,
+    "wof:lastmodified":1695886802,
     "wof:name":"Luuka",
     "wof:parent_id":85680097,
     "wof:placetype":"county",

--- a/data/109/207/243/9/1092072439.geojson
+++ b/data/109/207/243/9/1092072439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064215,
-    "geom:area_square_m":794027328.591987,
+    "geom:area_square_m":794027382.190281,
     "geom:bbox":"31.01221,-0.090034,31.327617,0.238413",
     "geom:latitude":0.07921,
     "geom:longitude":31.169884,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.SE.LW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899408,
-    "wof:geomhash":"8d71a80ef38ea97bfc1afa92e94fd52a",
+    "wof:geomhash":"51517505e2e921713a45d84174c5807a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072439,
-    "wof:lastmodified":1627522959,
+    "wof:lastmodified":1695886170,
     "wof:name":"Lwemiyaga",
     "wof:parent_id":85679823,
     "wof:placetype":"county",

--- a/data/109/207/248/1/1092072481.geojson
+++ b/data/109/207/248/1/1092072481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020591,
-    "geom:area_square_m":254573544.835183,
+    "geom:area_square_m":254573594.003646,
     "geom:bbox":"34.271047,0.96617,34.533896,1.118706",
     "geom:latitude":1.048337,
     "geom:longitude":34.396319,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BA.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899409,
-    "wof:geomhash":"87e7d0b6bb0a3c93407fd7fdf295565f",
+    "wof:geomhash":"911579dbb50c1baedc5b416c8c8d153f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072481,
-    "wof:lastmodified":1627522960,
+    "wof:lastmodified":1695886170,
     "wof:name":"Manjiya",
     "wof:parent_id":85680251,
     "wof:placetype":"county",

--- a/data/109/207/251/1/1092072511.geojson
+++ b/data/109/207/251/1/1092072511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035663,
-    "geom:area_square_m":440274477.293741,
+    "geom:area_square_m":440274159.922037,
     "geom:bbox":"30.801692,3.123219,31.074571,3.37199",
     "geom:latitude":3.24018,
     "geom:longitude":30.928058,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.MH.MR",
         "wd:id":"Q588927"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899410,
-    "wof:geomhash":"682b1eef377f99d77aa847c723dda3ca",
+    "wof:geomhash":"8ef219c03c95d2b9780b6ab8e6e981f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092072511,
-    "wof:lastmodified":1690877047,
+    "wof:lastmodified":1695886801,
     "wof:name":"Maracha",
     "wof:parent_id":85679861,
     "wof:placetype":"county",

--- a/data/109/207/255/1/1092072551.geojson
+++ b/data/109/207/255/1/1092072551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147776,
-    "geom:area_square_m":1826299594.686416,
+    "geom:area_square_m":1826299614.325679,
     "geom:bbox":"32.091214,1.612633,32.6575,2.222548",
     "geom:latitude":1.871973,
     "geom:longitude":32.430777,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AQ.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899412,
-    "wof:geomhash":"a9177bea4d0b017007331d07a4a2cddf",
+    "wof:geomhash":"00ab577db4f3affdc7b749d253ce6337",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072551,
-    "wof:lastmodified":1627522960,
+    "wof:lastmodified":1695886170,
     "wof:name":"Maruzi",
     "wof:parent_id":85680151,
     "wof:placetype":"county",

--- a/data/109/207/259/3/1092072593.geojson
+++ b/data/109/207/259/3/1092072593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003876,
-    "geom:area_square_m":47925526.118398,
+    "geom:area_square_m":47925568.570632,
     "geom:bbox":"31.692876,-0.372068,31.770103,-0.292378",
     "geom:latitude":-0.3305,
     "geom:longitude":31.735643,
@@ -200,9 +200,10 @@
         "hasc:id":"UG.MQ.MS",
         "wd:id":"Q1032233"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899414,
-    "wof:geomhash":"39e17eedfb71d6ed42246ca6ea520e64",
+    "wof:geomhash":"07e92d7653f573b1b67d5422a82af795",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -212,7 +213,7 @@
         }
     ],
     "wof:id":1092072593,
-    "wof:lastmodified":1690877046,
+    "wof:lastmodified":1695886709,
     "wof:name":"Masaka Municipality",
     "wof:parent_id":85680211,
     "wof:placetype":"county",

--- a/data/109/207/262/5/1092072625.geojson
+++ b/data/109/207/262/5/1092072625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287263,
-    "geom:area_square_m":3548231748.174888,
+    "geom:area_square_m":3548232071.693473,
     "geom:bbox":"34.280556,2.127289,34.955515,3.108778",
     "geom:latitude":2.652049,
     "geom:longitude":34.63076,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MX.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899415,
-    "wof:geomhash":"a96bff95b37027068daeaa96fd36ca1f",
+    "wof:geomhash":"3adabb694812c479413c4a11e6c87cee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072625,
-    "wof:lastmodified":1627522960,
+    "wof:lastmodified":1695886170,
     "wof:name":"Matheniko",
     "wof:parent_id":85680017,
     "wof:placetype":"county",

--- a/data/109/207/266/1/1092072661.geojson
+++ b/data/109/207/266/1/1092072661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124184,
-    "geom:area_square_m":1535548122.171312,
+    "geom:area_square_m":1535548240.090045,
     "geom:bbox":"31.272069,-0.342884,31.598039,0.212614",
     "geom:latitude":-0.075763,
     "geom:longitude":31.426868,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.SE.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899417,
-    "wof:geomhash":"ee6eee2459c307401ce67070f12fbdeb",
+    "wof:geomhash":"f2ab354e60c774620215d405207b5249",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072661,
-    "wof:lastmodified":1627522960,
+    "wof:lastmodified":1695886170,
     "wof:name":"Mawogola",
     "wof:parent_id":85679823,
     "wof:placetype":"county",

--- a/data/109/207/270/5/1092072705.geojson
+++ b/data/109/207/270/5/1092072705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123619,
-    "geom:area_square_m":1528568264.289762,
+    "geom:area_square_m":1528568078.007027,
     "geom:bbox":"31.871132,-0.15234,32.426883,0.408258",
     "geom:latitude":0.069946,
     "geom:longitude":32.158024,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MJ.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899419,
-    "wof:geomhash":"87869b5012c3fe1ae1156735e064b7a6",
+    "wof:geomhash":"cafa6830664d7297cbe903e6cfc28375",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072705,
-    "wof:lastmodified":1627522960,
+    "wof:lastmodified":1695886171,
     "wof:name":"Mawokota",
     "wof:parent_id":85679827,
     "wof:placetype":"county",

--- a/data/109/207/274/3/1092072743.geojson
+++ b/data/109/207/274/3/1092072743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00197,
-    "geom:area_square_m":24354604.329041,
+    "geom:area_square_m":24354659.305554,
     "geom:bbox":"34.14803,1.052747,34.206422,1.111452",
     "geom:latitude":1.07979,
     "geom:longitude":34.177163,
@@ -181,9 +181,10 @@
         "hasc:id":"UG.ME.MA",
         "wd:id":"Q581822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899420,
-    "wof:geomhash":"9b4c846eb60e5670b75b782c34385052",
+    "wof:geomhash":"a9e09e113b687ffa42601124eca79b02",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":1092072743,
-    "wof:lastmodified":1690877045,
+    "wof:lastmodified":1695886708,
     "wof:name":"Mbale Municipality",
     "wof:parent_id":85679965,
     "wof:placetype":"county",

--- a/data/109/207/277/5/1092072775.geojson
+++ b/data/109/207/277/5/1092072775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003673,
-    "geom:area_square_m":45414840.8805,
+    "geom:area_square_m":45414837.776262,
     "geom:bbox":"30.61288,-0.64016,30.699024,-0.580161",
     "geom:latitude":-0.609025,
     "geom:longitude":30.655504,
@@ -188,9 +188,10 @@
         "hasc:id":"UG.RR.MA",
         "wd:id":"Q1091595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899422,
-    "wof:geomhash":"e17553610346149c93f407377b0ebbd5",
+    "wof:geomhash":"1a7ba09234dd65fd074a1e07146c3618",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":1092072775,
-    "wof:lastmodified":1690877050,
+    "wof:lastmodified":1695886709,
     "wof:name":"Mbarara Municipality",
     "wof:parent_id":85680069,
     "wof:placetype":"county",

--- a/data/109/207/281/1/1092072811.geojson
+++ b/data/109/207/281/1/1092072811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088601,
-    "geom:area_square_m":1095524029.699842,
+    "geom:area_square_m":1095523829.464921,
     "geom:bbox":"31.882261,0.318701,32.261682,0.697595",
     "geom:latitude":0.508311,
     "geom:longitude":32.067809,
@@ -208,9 +208,10 @@
         "hasc:id":"UG.TY.MT",
         "wd:id":"Q1230005"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899423,
-    "wof:geomhash":"31408c4102c26a5d03f257de96a2120f",
+    "wof:geomhash":"382fd611bc51feb7aec3233abe14356b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -220,7 +221,7 @@
         }
     ],
     "wof:id":1092072811,
-    "wof:lastmodified":1690877046,
+    "wof:lastmodified":1695886801,
     "wof:name":"Mityana",
     "wof:parent_id":85679891,
     "wof:placetype":"county",

--- a/data/109/207/285/1/1092072851.geojson
+++ b/data/109/207/285/1/1092072851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000421,
-    "geom:area_square_m":5203036.509953,
+    "geom:area_square_m":5203009.090827,
     "geom:bbox":"34.646137,2.522497,34.672823,2.543674",
     "geom:latitude":2.532015,
     "geom:longitude":34.659496,
@@ -198,9 +198,10 @@
         "hasc:id":"UG.AL.MR",
         "wd:id":"Q1375850"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899425,
-    "wof:geomhash":"006732d327e016b63edfb3ff06d201e3",
+    "wof:geomhash":"9153bffaea33433d2c6e398b4d69752a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -216,7 +217,7 @@
         }
     ],
     "wof:id":1092072851,
-    "wof:lastmodified":1690877051,
+    "wof:lastmodified":1695886709,
     "wof:name":"Moroto Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/207/286/9/1092072869.geojson
+++ b/data/109/207/286/9/1092072869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124455,
-    "geom:area_square_m":1537698637.607126,
+    "geom:area_square_m":1537698902.651697,
     "geom:bbox":"32.977927,2.030501,33.547109,2.508548",
     "geom:latitude":2.270422,
     "geom:longitude":33.255838,
@@ -205,9 +205,10 @@
         "hasc:id":"UG.MX.MR",
         "wd:id":"Q1375850"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899426,
-    "wof:geomhash":"b7bba11a890f5886812c2a4256f3c28c",
+    "wof:geomhash":"e3c73e79a5e128072772fd7ef07edabb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1092072869,
-    "wof:lastmodified":1690877045,
+    "wof:lastmodified":1695886801,
     "wof:name":"Moroto",
     "wof:parent_id":85680161,
     "wof:placetype":"county",

--- a/data/109/207/291/1/1092072911.geojson
+++ b/data/109/207/291/1/1092072911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.269099,
-    "geom:area_square_m":3327363964.182712,
+    "geom:area_square_m":3327363723.007615,
     "geom:bbox":"32.504904,-1.0,32.9075,0.573593",
     "geom:latitude":-0.141302,
     "geom:longitude":32.771666,
@@ -205,9 +205,10 @@
         "hasc:id":"UG.MV.MM",
         "wd:id":"Q1151066"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899427,
-    "wof:geomhash":"bc62f5492e4a8f471556636c75fa92fc",
+    "wof:geomhash":"0d22a9f2ce7f41378b05a2513999f697",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1092072911,
-    "wof:lastmodified":1690877053,
+    "wof:lastmodified":1695886802,
     "wof:name":"Mukono",
     "wof:parent_id":85679817,
     "wof:placetype":"county",

--- a/data/109/207/295/5/1092072955.geojson
+++ b/data/109/207/295/5/1092072955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190927,
-    "geom:area_square_m":2360690154.669457,
+    "geom:area_square_m":2360690344.336449,
     "geom:bbox":"30.396393,0.349975,30.924679,0.939208",
     "geom:latitude":0.659423,
     "geom:longitude":30.661955,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.QJ.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899429,
-    "wof:geomhash":"e5f445af2dcab85e7a7f0045b8c4e355",
+    "wof:geomhash":"5afe5b47b658ae166537d9db1f4b2abd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092072955,
-    "wof:lastmodified":1627522960,
+    "wof:lastmodified":1695886171,
     "wof:name":"Mwenge",
     "wof:parent_id":85679943,
     "wof:placetype":"county",

--- a/data/109/207/298/5/1092072985.geojson
+++ b/data/109/207/298/5/1092072985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.282415,
-    "geom:area_square_m":3491497476.316724,
+    "geom:area_square_m":3491497440.926296,
     "geom:bbox":"31.821762,0.537061,32.499465,1.470917",
     "geom:latitude":1.051444,
     "geom:longitude":32.168359,
@@ -189,9 +189,10 @@
         "hasc:id":"UG.NK.NK",
         "wd:id":"Q432438"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899430,
-    "wof:geomhash":"b113a69807c306018e467ccb59d43be5",
+    "wof:geomhash":"25b828725b4a39f5cd2bd8629569d5ff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -201,7 +202,7 @@
         }
     ],
     "wof:id":1092072985,
-    "wof:lastmodified":1690877052,
+    "wof:lastmodified":1695886802,
     "wof:name":"Nakaseke",
     "wof:parent_id":85679895,
     "wof:placetype":"county",

--- a/data/109/207/301/5/1092073015.geojson
+++ b/data/109/207/301/5/1092073015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067654,
-    "geom:area_square_m":836508943.122078,
+    "geom:area_square_m":836508804.432959,
     "geom:bbox":"32.703734,0.368941,32.982756,0.859145",
     "geom:latitude":0.59078,
     "geom:longitude":32.84408,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MV.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899432,
-    "wof:geomhash":"53e9a66af45d5977403db283ee7fc669",
+    "wof:geomhash":"777f2da328b604e5cea234355a8ea5c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073015,
-    "wof:lastmodified":1627522961,
+    "wof:lastmodified":1695886171,
     "wof:name":"Nakifuma",
     "wof:parent_id":85679817,
     "wof:placetype":"county",

--- a/data/109/207/306/1/1092073061.geojson
+++ b/data/109/207/306/1/1092073061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045525,
-    "geom:area_square_m":562772557.295712,
+    "geom:area_square_m":562772475.055925,
     "geom:bbox":"29.890147,-1.481483,30.174403,-1.194947",
     "geom:latitude":-1.329891,
     "geom:longitude":30.027598,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KA.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899433,
-    "wof:geomhash":"d73d91bb07e7adac080ea1adef4227f7",
+    "wof:geomhash":"df4b851287fbbdaa7fa3e6e698311e79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073061,
-    "wof:lastmodified":1627522961,
+    "wof:lastmodified":1695886171,
     "wof:name":"Ndorwa",
     "wof:parent_id":85680073,
     "wof:placetype":"county",

--- a/data/109/207/310/7/1092073107.geojson
+++ b/data/109/207/310/7/1092073107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058634,
-    "geom:area_square_m":724765712.162372,
+    "geom:area_square_m":724765902.470407,
     "geom:bbox":"33.555351,1.312037,33.900281,1.68514",
     "geom:latitude":1.499049,
     "geom:longitude":33.753482,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.NR.NO",
         "wd:id":"Q1114903"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899435,
-    "wof:geomhash":"16ea4ac145b1d8601ff181b52c264a7c",
+    "wof:geomhash":"4e8b461088060561ea7728b2a457e1b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092073107,
-    "wof:lastmodified":1690877055,
+    "wof:lastmodified":1695886803,
     "wof:name":"Ngora",
     "wof:parent_id":85680089,
     "wof:placetype":"county",

--- a/data/109/207/314/1/1092073141.geojson
+++ b/data/109/207/314/1/1092073141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043323,
-    "geom:area_square_m":535653125.91302,
+    "geom:area_square_m":535653487.839088,
     "geom:bbox":"32.821867,0.5075,33.083691,0.906074",
     "geom:latitude":0.699373,
     "geom:longitude":32.975397,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KY.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899437,
-    "wof:geomhash":"4a82cc55bdf6e9e1c4c8f5e8850f68fe",
+    "wof:geomhash":"74fd7a9a2ed978e62b10da9a7e819ac5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092073141,
-    "wof:lastmodified":1627522961,
+    "wof:lastmodified":1695886171,
     "wof:name":"Ntenjeru",
     "wof:parent_id":85679787,
     "wof:placetype":"county",

--- a/data/109/207/317/9/1092073179.geojson
+++ b/data/109/207/317/9/1092073179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11212,
-    "geom:area_square_m":1386162534.169973,
+    "geom:area_square_m":1386162239.315245,
     "geom:bbox":"30.152506,0.721136,30.551756,1.288697",
     "geom:latitude":1.012384,
     "geom:longitude":30.363292,
@@ -190,9 +190,10 @@
         "hasc:id":"UG.NO.NO",
         "wd:id":"Q3539547"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899438,
-    "wof:geomhash":"4ecf59f6376481f624bd29c10f792ecf",
+    "wof:geomhash":"58192ff930ac3b69550776b1379f8c79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1092073179,
-    "wof:lastmodified":1690877054,
+    "wof:lastmodified":1695886802,
     "wof:name":"Ntoroko",
     "wof:parent_id":85680179,
     "wof:placetype":"county",

--- a/data/109/207/322/5/1092073225.geojson
+++ b/data/109/207/322/5/1092073225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.388144,
-    "geom:area_square_m":4794786520.662314,
+    "geom:area_square_m":4794786539.340186,
     "geom:bbox":"31.33775,2.217803,32.35975,2.837462",
     "geom:latitude":2.530242,
     "geom:longitude":31.840608,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.NW.NO",
         "wd:id":"Q3539572"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899440,
-    "wof:geomhash":"df7d227ded094d73c0dce7ac86b7c8ae",
+    "wof:geomhash":"33bc75c2e69ec24764ee453df5268937",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092073225,
-    "wof:lastmodified":1690877049,
+    "wof:lastmodified":1695886801,
     "wof:name":"Nwoya",
     "wof:parent_id":85680247,
     "wof:placetype":"county",

--- a/data/109/207/325/5/1092073255.geojson
+++ b/data/109/207/325/5/1092073255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.24712,
-    "geom:area_square_m":3055619244.309371,
+    "geom:area_square_m":3055619351.669647,
     "geom:bbox":"30.607107,-0.712653,31.154197,0.057552",
     "geom:latitude":-0.347295,
     "geom:longitude":30.91375,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KH.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899441,
-    "wof:geomhash":"20234b97a8cd425b28c0d8519e8a9adb",
+    "wof:geomhash":"7f16213bb01a41a9f5cdc0e696a6d1f0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073255,
-    "wof:lastmodified":1627522961,
+    "wof:lastmodified":1695886171,
     "wof:name":"Nyabushozi",
     "wof:parent_id":1108808411,
     "wof:placetype":"county",

--- a/data/109/207/329/9/1092073299.geojson
+++ b/data/109/207/329/9/1092073299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069488,
-    "geom:area_square_m":857728571.894099,
+    "geom:area_square_m":857728530.342526,
     "geom:bbox":"31.426361,3.152139,31.768537,3.578108",
     "geom:latitude":3.395595,
     "geom:longitude":31.555553,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MY.OO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899442,
-    "wof:geomhash":"a70ebdf64fe65386b5e33d8bba3c159a",
+    "wof:geomhash":"ee897df66b8f62880be936da19266733",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073299,
-    "wof:lastmodified":1627522961,
+    "wof:lastmodified":1695886171,
     "wof:name":"Obongi",
     "wof:parent_id":85679853,
     "wof:placetype":"county",

--- a/data/109/207/333/9/1092073339.geojson
+++ b/data/109/207/333/9/1092073339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073345,
-    "geom:area_square_m":906041513.166461,
+    "geom:area_square_m":906040813.264979,
     "geom:bbox":"30.740743,2.329511,31.070584,2.713084",
     "geom:latitude":2.520594,
     "geom:longitude":30.895999,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.ZO.OO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899444,
-    "wof:geomhash":"f4d891c800f3b135beb9051ebb1559e9",
+    "wof:geomhash":"67ea647832ab55e69dfedae70e4f2c5c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073339,
-    "wof:lastmodified":1627522961,
+    "wof:lastmodified":1695886171,
     "wof:name":"Okoro",
     "wof:parent_id":85680085,
     "wof:placetype":"county",

--- a/data/109/207/337/7/1092073377.geojson
+++ b/data/109/207/337/7/1092073377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128687,
-    "geom:area_square_m":1589515976.422643,
+    "geom:area_square_m":1589515834.315251,
     "geom:bbox":"32.128427,2.452467,32.823856,2.841301",
     "geom:latitude":2.669321,
     "geom:longitude":32.471102,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.GL.OO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899445,
-    "wof:geomhash":"49da1ddb5bad692a0941afa7f0d44dd8",
+    "wof:geomhash":"34655d1a9c63ea86c2d749a261805607",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092073377,
-    "wof:lastmodified":1627522961,
+    "wof:lastmodified":1695886172,
     "wof:name":"Omoro",
     "wof:parent_id":85679905,
     "wof:placetype":"county",

--- a/data/109/207/341/3/1092073413.geojson
+++ b/data/109/207/341/3/1092073413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125543,
-    "geom:area_square_m":1550909081.055912,
+    "geom:area_square_m":1550908708.806415,
     "geom:bbox":"33.003565,2.324381,33.657565,2.630011",
     "geom:latitude":2.481116,
     "geom:longitude":33.362605,
@@ -196,9 +196,10 @@
         "hasc:id":"UG.OT.OU",
         "wd:id":"Q3539602"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899447,
-    "wof:geomhash":"34e83a3745b8168aa74c287cfac9d4f1",
+    "wof:geomhash":"4a0c3519f79e37ba54d526185ee77e4f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1092073413,
-    "wof:lastmodified":1690877048,
+    "wof:lastmodified":1695886801,
     "wof:name":"Otuke",
     "wof:parent_id":85680165,
     "wof:placetype":"county",

--- a/data/109/207/344/9/1092073449.geojson
+++ b/data/109/207/344/9/1092073449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178312,
-    "geom:area_square_m":2202964916.945148,
+    "geom:area_square_m":2202964916.945081,
     "geom:bbox":"32.227142,2.074984,32.822472,2.623293",
     "geom:latitude":2.371004,
     "geom:longitude":32.486473,
@@ -202,12 +202,13 @@
         "hasc:id":"UG.OY.OA",
         "wd:id":"Q1318833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85679927
     ],
     "wof:country":"UG",
     "wof:created":1473899448,
-    "wof:geomhash":"e5d6ec137cf1f9d3e5ff99141c0d11cf",
+    "wof:geomhash":"b3b702d84c0225f83a60a89053d91a68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1092073449,
-    "wof:lastmodified":1690877055,
+    "wof:lastmodified":1695886803,
     "wof:name":"Oyam",
     "wof:parent_id":85679927,
     "wof:placetype":"county",

--- a/data/109/207/348/9/1092073489.geojson
+++ b/data/109/207/348/9/1092073489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081184,
-    "geom:area_square_m":1002945704.325078,
+    "geom:area_square_m":1002945645.021752,
     "geom:bbox":"31.001006,2.196163,31.30919,2.677695",
     "geom:latitude":2.435218,
     "geom:longitude":31.178276,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NB.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899450,
-    "wof:geomhash":"a546240f180357bd20acc55cd56f6d3f",
+    "wof:geomhash":"adbb9789593f6692dbad2b81c321261c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073489,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886172,
     "wof:name":"Padyere",
     "wof:parent_id":85679849,
     "wof:placetype":"county",

--- a/data/109/207/352/3/1092073523.geojson
+++ b/data/109/207/352/3/1092073523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0627,
-    "geom:area_square_m":775123279.169042,
+    "geom:area_square_m":775123506.242627,
     "geom:bbox":"33.39561,1.092304,33.872895,1.3475",
     "geom:latitude":1.233976,
     "geom:longitude":33.659179,
@@ -202,9 +202,10 @@
         "hasc:id":"UG.PS.PS",
         "wd:id":"Q1375843"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899451,
-    "wof:geomhash":"bd277170b6e2e5c9303cd3ee0c703867",
+    "wof:geomhash":"71f8888f804f551d53146c20c312dacd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":1092073523,
-    "wof:lastmodified":1690877044,
+    "wof:lastmodified":1695886801,
     "wof:name":"Pallisa",
     "wof:parent_id":85679819,
     "wof:placetype":"county",

--- a/data/109/207/356/7/1092073567.geojson
+++ b/data/109/207/356/7/1092073567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138693,
-    "geom:area_square_m":1713866218.361608,
+    "geom:area_square_m":1713866218.36149,
     "geom:bbox":"34.2207478653,1.75114373799,34.7942393221,2.44137591002",
     "geom:latitude":2.050662,
     "geom:longitude":34.521714,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NI.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899453,
-    "wof:geomhash":"e9cc5e6a23ed8625be82c97f42e02f76",
+    "wof:geomhash":"d6da0656a4e8f34956ee0874f2d9a2f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092073567,
-    "wof:lastmodified":1566595443,
+    "wof:lastmodified":1695886709,
     "wof:name":"Pian",
     "wof:parent_id":85680021,
     "wof:placetype":"county",

--- a/data/109/207/360/1/1092073601.geojson
+++ b/data/109/207/360/1/1092073601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134828,
-    "geom:area_square_m":1666326020.069568,
+    "geom:area_square_m":1666326041.560728,
     "geom:bbox":"34.622266,1.367992,35.033049,2.28813",
     "geom:latitude":1.810133,
     "geom:longitude":34.88034,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NP.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899454,
-    "wof:geomhash":"c9ff82db428f7104c13e8a279b7e219c",
+    "wof:geomhash":"f3ca6316301fece8bd2d5116c4377fe1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1092073601,
-    "wof:lastmodified":1627522963,
+    "wof:lastmodified":1695886173,
     "wof:name":"Upe",
     "wof:parent_id":85680209,
     "wof:placetype":"county",

--- a/data/109/207/363/7/1092073637.geojson
+++ b/data/109/207/363/7/1092073637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040174,
-    "geom:area_square_m":496698511.529557,
+    "geom:area_square_m":496698577.753204,
     "geom:bbox":"29.849015,-1.057898,30.074627,-0.774049",
     "geom:latitude":-0.921035,
     "geom:longitude":29.96971,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RK.RB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899455,
-    "wof:geomhash":"fc24ba3a2205b4a4520fb3609e2a0a07",
+    "wof:geomhash":"cb0d54521ccb29f14c9e8b5921a93784",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073637,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886172,
     "wof:name":"Rubabo",
     "wof:parent_id":85680061,
     "wof:placetype":"county",

--- a/data/109/207/367/3/1092073673.geojson
+++ b/data/109/207/367/3/1092073673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058831,
-    "geom:area_square_m":727299645.758481,
+    "geom:area_square_m":727299112.799836,
     "geom:bbox":"29.72708,-1.435425,30.029289,-0.987693",
     "geom:latitude":-1.179,
     "geom:longitude":29.867416,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KA.RB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899457,
-    "wof:geomhash":"43d65870f985b1e2bed8eeda81c7eb3f",
+    "wof:geomhash":"df30dcdb6d6fff715b2c062ce1465117",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073673,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886172,
     "wof:name":"Rubanda",
     "wof:parent_id":85680073,
     "wof:placetype":"county",

--- a/data/109/207/371/3/1092073713.geojson
+++ b/data/109/207/371/3/1092073713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086246,
-    "geom:area_square_m":1066318531.849547,
+    "geom:area_square_m":1066318350.044997,
     "geom:bbox":"30.202646,-1.068936,30.632699,-0.719256",
     "geom:latitude":-0.904143,
     "geom:longitude":30.377732,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NT.RH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899458,
-    "wof:geomhash":"7610e9eff32ac59b5fd44f6e39892ae3",
+    "wof:geomhash":"85a061cdc677fa15112f569429b4f179",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073713,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886172,
     "wof:name":"Ruhaama",
     "wof:parent_id":85680059,
     "wof:placetype":"county",

--- a/data/109/207/375/3/1092073753.geojson
+++ b/data/109/207/375/3/1092073753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044092,
-    "geom:area_square_m":545167887.417001,
+    "geom:area_square_m":545167780.452743,
     "geom:bbox":"29.885485,-0.776341,30.160008,-0.437224",
     "geom:latitude":-0.621644,
     "geom:longitude":30.021619,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MM.RH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899460,
-    "wof:geomhash":"219d6b1e63e39dbb6cdf2a0e70df29a8",
+    "wof:geomhash":"e7a0133170a21a4929be5b22d981c05e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073753,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886172,
     "wof:name":"Ruhinda",
     "wof:parent_id":85680233,
     "wof:placetype":"county",

--- a/data/109/207/378/3/1092073783.geojson
+++ b/data/109/207/378/3/1092073783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034954,
-    "geom:area_square_m":432122130.316414,
+    "geom:area_square_m":432122265.032947,
     "geom:bbox":"29.917754,-1.2815,30.300882,-1.009565",
     "geom:latitude":-1.148666,
     "geom:longitude":30.092483,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KA.RK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899461,
-    "wof:geomhash":"15a7819aad633c33345169a93fe72676",
+    "wof:geomhash":"9a4eb0968a63462de69d65b4c523f19b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073783,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886173,
     "wof:name":"Rukiga",
     "wof:parent_id":85680073,
     "wof:placetype":"county",

--- a/data/109/207/382/5/1092073825.geojson
+++ b/data/109/207/382/5/1092073825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055194,
-    "geom:area_square_m":682368154.543019,
+    "geom:area_square_m":682368179.225335,
     "geom:bbox":"30.027645,-1.192797,30.377196,-0.8805",
     "geom:latitude":-1.044869,
     "geom:longitude":30.178974,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.NT.RS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899463,
-    "wof:geomhash":"bdb90ee477ab2e88cbc7f9f02d2e0393",
+    "wof:geomhash":"aedbfead0dadcf331ddaa498aac5b90f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073825,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886173,
     "wof:name":"Rushenyi",
     "wof:parent_id":85680059,
     "wof:placetype":"county",

--- a/data/109/207/388/1/1092073881.geojson
+++ b/data/109/207/388/1/1092073881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056578,
-    "geom:area_square_m":699540336.929995,
+    "geom:area_square_m":699540309.485864,
     "geom:bbox":"30.31884,-0.843678,30.655149,-0.586738",
     "geom:latitude":-0.723046,
     "geom:longitude":30.509366,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RR.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899465,
-    "wof:geomhash":"68c6a88fb065ab8bdade5b5c2cf80272",
+    "wof:geomhash":"b501b96cbd1da598484a4c29374f5774",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092073881,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886173,
     "wof:name":"Rwampara",
     "wof:parent_id":85680069,
     "wof:placetype":"county",

--- a/data/109/207/389/7/1092073897.geojson
+++ b/data/109/207/389/7/1092073897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062672,
-    "geom:area_square_m":774928373.007268,
+    "geom:area_square_m":774927988.842409,
     "geom:bbox":"33.87894,0.190005,34.138574,0.594877",
     "geom:latitude":0.413669,
     "geom:longitude":34.005336,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BU.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899466,
-    "wof:geomhash":"8eeb7ecdd1d4db342c1dec0fe9b0c283",
+    "wof:geomhash":"83fb223b2c8b456ed133140beb7a32df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092073897,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886173,
     "wof:name":"Samia-bugwe",
     "wof:parent_id":85679979,
     "wof:placetype":"county",

--- a/data/109/207/393/9/1092073939.geojson
+++ b/data/109/207/393/9/1092073939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067092,
-    "geom:area_square_m":829322062.817211,
+    "geom:area_square_m":829322104.742054,
     "geom:bbox":"33.383678,1.31191,33.707362,1.676257",
     "geom:latitude":1.492672,
     "geom:longitude":33.532448,
@@ -193,9 +193,10 @@
         "hasc:id":"UG.SX.SE",
         "wd:id":"Q1114927"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899468,
-    "wof:geomhash":"691595cd6d7912eb6bdd564ab546a577",
+    "wof:geomhash":"480347ba8c99d2260000cc4453a025fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092073939,
-    "wof:lastmodified":1690877049,
+    "wof:lastmodified":1695886802,
     "wof:name":"Serere",
     "wof:parent_id":85680119,
     "wof:placetype":"county",

--- a/data/109/207/398/3/1092073983.geojson
+++ b/data/109/207/398/3/1092073983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056771,
-    "geom:area_square_m":701948180.276792,
+    "geom:area_square_m":701948032.964989,
     "geom:bbox":"30.116694,-0.762059,30.477506,-0.423225",
     "geom:latitude":-0.601639,
     "geom:longitude":30.325648,
@@ -190,9 +190,10 @@
         "hasc:id":"UG.SH.SE",
         "wd:id":"Q3539711"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899469,
-    "wof:geomhash":"d14508ecdc6d0516c448fc24810d4f6f",
+    "wof:geomhash":"3391e90c12a6ff3e67c871cba897cfed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1092073983,
-    "wof:lastmodified":1690877044,
+    "wof:lastmodified":1695886801,
     "wof:name":"Sheema",
     "wof:parent_id":85680237,
     "wof:placetype":"county",

--- a/data/109/207/401/7/1092074017.geojson
+++ b/data/109/207/401/7/1092074017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002126,
-    "geom:area_square_m":26281001.698359,
+    "geom:area_square_m":26280935.343657,
     "geom:bbox":"33.569202,1.696258,33.632992,1.751621",
     "geom:latitude":1.72488,
     "geom:longitude":33.604406,
@@ -187,9 +187,10 @@
         "hasc:id":"UG.SR.SM",
         "wd:id":"Q1091337"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899470,
-    "wof:geomhash":"d658023eee78eaa2eeb7b205b90078b8",
+    "wof:geomhash":"a175b98e51c8c38551390e5b95aa6125",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":1092074017,
-    "wof:lastmodified":1690877046,
+    "wof:lastmodified":1695886709,
     "wof:name":"Soroti Municipality",
     "wof:parent_id":85679813,
     "wof:placetype":"county",

--- a/data/109/207/405/5/1092074055.geojson
+++ b/data/109/207/405/5/1092074055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1127,
-    "geom:area_square_m":1392887075.967472,
+    "geom:area_square_m":1392887075.967439,
     "geom:bbox":"33.395973,1.55864,33.814237,2.023329",
     "geom:latitude":1.775449,
     "geom:longitude":33.590005,
@@ -199,12 +199,13 @@
         "hasc:id":"UG.ST.SM",
         "wd:id":"Q1091337"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85679813
     ],
     "wof:country":"UG",
     "wof:created":1473899472,
-    "wof:geomhash":"95dedda5a1e735262b840dec90d2887d",
+    "wof:geomhash":"37a1c9cc4cad3ccb8573d6f85c007f80",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":1092074055,
-    "wof:lastmodified":1690877052,
+    "wof:lastmodified":1695886802,
     "wof:name":"Soroti",
     "wof:parent_id":85679813,
     "wof:placetype":"county",

--- a/data/109/207/409/7/1092074097.geojson
+++ b/data/109/207/409/7/1092074097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091761,
-    "geom:area_square_m":1132897791.5154,
+    "geom:area_square_m":1132898394.811067,
     "geom:bbox":"30.930001,3.01284,31.4246,3.356942",
     "geom:latitude":3.177906,
     "geom:longitude":31.16596,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AX.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899474,
-    "wof:geomhash":"9bb12be3f0cd01b67e8c1dbcbd4492d8",
+    "wof:geomhash":"3fa5db7396fdf38844552b6c949a7eb3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092074097,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886173,
     "wof:name":"Terego",
     "wof:parent_id":85679861,
     "wof:placetype":"county",

--- a/data/109/207/413/7/1092074137.geojson
+++ b/data/109/207/413/7/1092074137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028786,
-    "geom:area_square_m":355846730.627284,
+    "geom:area_square_m":355846886.422293,
     "geom:bbox":"34.303603,1.197292,34.537415,1.477866",
     "geom:latitude":1.351863,
     "geom:longitude":34.422162,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.QP.TI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899475,
-    "wof:geomhash":"778cebfd98f3d6ba6e7b1d45de3e2940",
+    "wof:geomhash":"807577bb0923d133169b82b8cd1fd0d1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092074137,
-    "wof:lastmodified":1627522962,
+    "wof:lastmodified":1695886173,
     "wof:name":"Tingey",
     "wof:parent_id":85679951,
     "wof:placetype":"county",

--- a/data/109/207/417/3/1092074173.geojson
+++ b/data/109/207/417/3/1092074173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002569,
-    "geom:area_square_m":31769342.721445,
+    "geom:area_square_m":31769282.039761,
     "geom:bbox":"34.154578,0.654125,34.212351,0.71721",
     "geom:latitude":0.687101,
     "geom:longitude":34.182537,
@@ -197,9 +197,10 @@
         "hasc:id":"UG.TR.TR",
         "wd:id":"Q1186541"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899477,
-    "wof:geomhash":"a4a9a76b35a4013c4a2545e1ee047abb",
+    "wof:geomhash":"a5ce2da7322648ce7ed69a2815605fd8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":1092074173,
-    "wof:lastmodified":1690877050,
+    "wof:lastmodified":1695886709,
     "wof:name":"Tororo Municipality",
     "wof:parent_id":85679989,
     "wof:placetype":"county",

--- a/data/109/207/421/3/1092074213.geojson
+++ b/data/109/207/421/3/1092074213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032864,
-    "geom:area_square_m":406332993.063162,
+    "geom:area_square_m":406332896.044228,
     "geom:bbox":"34.052435,0.580185,34.313723,0.907421",
     "geom:latitude":0.737216,
     "geom:longitude":34.187887,
@@ -199,9 +199,10 @@
         "hasc:id":"UG.TR.TO",
         "wd:id":"Q1186541"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899478,
-    "wof:geomhash":"ae2ae7f4b39c1cb76fe427e44b66beca",
+    "wof:geomhash":"55c00e58a39537d47396b9a269972606",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1092074213,
-    "wof:lastmodified":1690877050,
+    "wof:lastmodified":1695886802,
     "wof:name":"Tororo",
     "wof:parent_id":85679989,
     "wof:placetype":"county",

--- a/data/109/207/424/5/1092074245.geojson
+++ b/data/109/207/424/5/1092074245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.197564,
-    "geom:area_square_m":2441533950.966856,
+    "geom:area_square_m":2441534159.848349,
     "geom:bbox":"33.808598,1.6375,34.224282,2.307206",
     "geom:latitude":1.925083,
     "geom:longitude":34.037306,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.KK.US"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899480,
-    "wof:geomhash":"46c0bd68ab2bf952cf8cc4b0576d1586",
+    "wof:geomhash":"2ab56e160bcb0d552e8dd43e05289ab0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092074245,
-    "wof:lastmodified":1627522963,
+    "wof:lastmodified":1695886173,
     "wof:name":"Usuk",
     "wof:parent_id":85679995,
     "wof:placetype":"county",

--- a/data/109/207/425/9/1092074259.geojson
+++ b/data/109/207/425/9/1092074259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062425,
-    "geom:area_square_m":770938812.39826,
+    "geom:area_square_m":770938404.642385,
     "geom:bbox":"30.796668,2.65402,31.143344,3.029253",
     "geom:latitude":2.856116,
     "geom:longitude":30.967537,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AX.VU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899481,
-    "wof:geomhash":"f054f4bd7c2a9800761d5747493be242",
+    "wof:geomhash":"d90b7d0ca6f81d24e4ea6b93ab81bbdb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092074259,
-    "wof:lastmodified":1627522963,
+    "wof:lastmodified":1695886173,
     "wof:name":"Vurra",
     "wof:parent_id":85679837,
     "wof:placetype":"county",

--- a/data/109/207/428/9/1092074289.geojson
+++ b/data/109/207/428/9/1092074289.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"UG.TR.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899483,
     "wof:geomhash":"cb28ea3dbcc4bf28b04b2b4e2328e682",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092074289,
-    "wof:lastmodified":1694639797,
+    "wof:lastmodified":1695886169,
     "wof:name":"Kisoko",
     "wof:parent_id":85679989,
     "wof:placetype":"county",

--- a/data/109/207/432/1/1092074321.geojson
+++ b/data/109/207/432/1/1092074321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081582,
-    "geom:area_square_m":1006740058.620153,
+    "geom:area_square_m":1006740422.107713,
     "geom:bbox":"31.514361,3.511468,31.976439,3.836599",
     "geom:latitude":3.644147,
     "geom:longitude":31.765894,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.MY.WS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899485,
-    "wof:geomhash":"c24c5ce6d11060f049fa0421a2930010",
+    "wof:geomhash":"1119d9ae98ac6e3c199af1b8d30dbb63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092074321,
-    "wof:lastmodified":1627522963,
+    "wof:lastmodified":1695886174,
     "wof:name":"West Moyo",
     "wof:parent_id":85679853,
     "wof:placetype":"county",

--- a/data/109/207/434/3/1092074343.geojson
+++ b/data/109/207/434/3/1092074343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106873,
-    "geom:area_square_m":1321489389.102592,
+    "geom:area_square_m":1321489191.153162,
     "geom:bbox":"29.676924,-0.4475,30.287321,-0.06289",
     "geom:latitude":-0.246709,
     "geom:longitude":29.98537,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"UG.RZ.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899486,
-    "wof:geomhash":"5ea1dd6e1b3621b2bae51cc49e789e35",
+    "wof:geomhash":"d97ca5c568684a1bba779a02783472af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092074343,
-    "wof:lastmodified":1627522954,
+    "wof:lastmodified":1695886165,
     "wof:name":"Bunyaruguru",
     "wof:parent_id":85680229,
     "wof:placetype":"county",

--- a/data/109/207/438/3/1092074383.geojson
+++ b/data/109/207/438/3/1092074383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044855,
-    "geom:area_square_m":554597216.912772,
+    "geom:area_square_m":554597301.042708,
     "geom:bbox":"29.911667,0.4026,30.204903,0.895043",
     "geom:latitude":0.678546,
     "geom:longitude":30.073652,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BX.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899488,
-    "wof:geomhash":"71e85863c891da94a7e852983bb65e41",
+    "wof:geomhash":"7f77f93a57c32e9321c3bb2cdf30a34d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092074383,
-    "wof:lastmodified":1627522956,
+    "wof:lastmodified":1695886167,
     "wof:name":"Bwamba",
     "wof:parent_id":85679929,
     "wof:placetype":"county",

--- a/data/109/207/442/5/1092074425.geojson
+++ b/data/109/207/442/5/1092074425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.317687,
-    "geom:area_square_m":3924723523.971667,
+    "geom:area_square_m":3924723335.563938,
     "geom:bbox":"30.974561,1.343662,31.750298,3.193216",
     "geom:latitude":2.36747,
     "geom:longitude":31.40662,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"UG.AX.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899489,
-    "wof:geomhash":"f26ff1c6f217c4b290e616a0a5fc1250",
+    "wof:geomhash":"42e29e81716be5da8cd6c23f13886a35",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1092074425,
-    "wof:lastmodified":1627522960,
+    "wof:lastmodified":1695886171,
     "wof:name":"Madi-okollo",
     "wof:parent_id":85679921,
     "wof:placetype":"county",

--- a/data/109/207/446/1/1092074461.geojson
+++ b/data/109/207/446/1/1092074461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.627355,
-    "geom:area_square_m":7757110615.115157,
+    "geom:area_square_m":7757111645.87081,
     "geom:bbox":"32.191712,-1.0,33.984247,0.734886",
     "geom:latitude":-0.070341,
     "geom:longitude":33.438969,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"UG.BI.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1473899490,
-    "wof:geomhash":"02ecbad77db293dc5683fec59e01d3d1",
+    "wof:geomhash":"6dca8aa4861d64622cd6f3ea7816a8a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092074461,
-    "wof:lastmodified":1627522955,
+    "wof:lastmodified":1695886166,
     "wof:name":"Busiro",
     "wof:parent_id":85679975,
     "wof:placetype":"county",

--- a/data/110/880/840/9/1108808409.geojson
+++ b/data/110/880/840/9/1108808409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195469,
-    "geom:area_square_m":2416539218.598976,
+    "geom:area_square_m":2416539218.598921,
     "geom:bbox":"31.293081,0.822585,31.919139,1.368766",
     "geom:latitude":1.128281,
     "geom:longitude":31.637712,
@@ -197,12 +197,14 @@
     "wof:concordances":{
         "fips:code":"UGG1",
         "hasc:id":"UG.QZ",
+        "iso:code":"UG-123",
         "iso:id":"UG-123",
         "wd:id":"Q534203"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:created":1486157728,
-    "wof:geomhash":"59ca6380e90f524c51d10b3bfb27ee3d",
+    "wof:geomhash":"7f339719af6bdc6a580810642d4b2f14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -219,7 +221,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877043,
+    "wof:lastmodified":1695884918,
     "wof:name":"Kyankwanzi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/110/880/841/1/1108808411.geojson
+++ b/data/110/880/841/1/1108808411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.373749,
-    "geom:area_square_m":4621405305.871979,
+    "geom:area_square_m":4621405104.439085,
     "geom:bbox":"30.5675,-0.712653,31.154197,0.213906",
     "geom:latitude":-0.214664,
     "geom:longitude":30.872382,
@@ -23,7 +23,7 @@
     "lbl:longitude":30.848655,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":10.0,
     "name:ara_x_preferred":[
@@ -59,11 +59,13 @@
     "wof:concordances":{
         "fips:code":"UGD3",
         "hasc:id":"UG.KH",
+        "iso:code":"UG-418",
         "iso:id":"UG-418"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:created":1486157729,
-    "wof:geomhash":"bd6542069807b775e0bffd7f6a54b838",
+    "wof:geomhash":"1725050ceb16bc7d1089ea5d246c786c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +82,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1627522958,
+    "wof:lastmodified":1695884285,
     "wof:name":"Kiruhura",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/421/174/009/421174009.geojson
+++ b/data/421/174/009/421174009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00317,
-    "geom:area_square_m":39197619.412798,
+    "geom:area_square_m":39197596.404816,
     "geom:bbox":"30.251656,0.618321,30.321065,0.701112",
     "geom:latitude":0.655574,
     "geom:longitude":30.281449,
@@ -365,12 +365,13 @@
         "wd:id":"Q1229910",
         "wk:page":"Fort Portal"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1459009017,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"95fc9aeae93728ddadaf5791c775eb29",
+    "wof:geomhash":"9eeaf6435c88cbd0f66a45350a29a5ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -380,7 +381,7 @@
         }
     ],
     "wof:id":421174009,
-    "wof:lastmodified":1690877061,
+    "wof:lastmodified":1695886795,
     "wof:name":"Fort Portal Municipality",
     "wof:parent_id":85679939,
     "wof:placetype":"county",

--- a/data/421/202/527/421202527.geojson
+++ b/data/421/202/527/421202527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145299,
-    "geom:area_square_m":1796624477.581046,
+    "geom:area_square_m":1796624381.774945,
     "geom:bbox":"30.253463,0.047714,30.858636,0.57806",
     "geom:latitude":0.308652,
     "geom:longitude":30.543516,
@@ -319,12 +319,13 @@
         "qs_pg:id":224069,
         "wd:id":"Q604966"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"UG",
     "wof:created":1459010121,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"861348ba39c15f78209602496a33c4c2",
+    "wof:geomhash":"8ef2181d822d8105f4055b9e4a2c994e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -334,7 +335,7 @@
         }
     ],
     "wof:id":421202527,
-    "wof:lastmodified":1690877060,
+    "wof:lastmodified":1695886803,
     "wof:name":"Kibale",
     "wof:parent_id":85680041,
     "wof:placetype":"county",

--- a/data/856/326/25/85632625.geojson
+++ b/data/856/326/25/85632625.geojson
@@ -1115,6 +1115,7 @@
         "hasc:id":"UG",
         "icao:code":"5X",
         "ioc:id":"UGA",
+        "iso:code":"UG",
         "itu:id":"UGA",
         "loc:id":"n80126332",
         "m49:code":"800",
@@ -1129,6 +1130,7 @@
         "wk:page":"Uganda",
         "wmo:id":"UG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:country_alpha3":"UGA",
     "wof:geom_alt":[
@@ -1152,7 +1154,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1694639545,
+    "wof:lastmodified":1695881202,
     "wof:name":"Uganda",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/797/69/85679769.geojson
+++ b/data/856/797/69/85679769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.632286,
-    "geom:area_square_m":7817872538.206674,
+    "geom:area_square_m":7817872498.414597,
     "geom:bbox":"31.9925,-1.0,32.754561,-0.147358",
     "geom:latitude":-0.577824,
     "geom:longitude":32.377653,
@@ -289,16 +289,18 @@
         "gn:id":443338,
         "gp:id":20070420,
         "hasc:id":"UG.KN",
+        "iso:code":"UG-101",
         "iso:id":"UG-101",
         "qs_pg:id":890567,
         "unlc:id":"UG-101",
         "wd:id":"Q867219"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e56eaf0ba37c3924df7b5ed0d1c2bf20",
+    "wof:geomhash":"89c27be1270c0ac0130c63716758b108",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877013,
+    "wof:lastmodified":1695884912,
     "wof:name":"Kalangala",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/73/85679773.geojson
+++ b/data/856/797/73/85679773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059417,
-    "geom:area_square_m":734671241.348291,
+    "geom:area_square_m":734671111.493234,
     "geom:bbox":"33.042154,0.393397,33.37795,0.700314",
     "geom:latitude":0.56746,
     "geom:longitude":33.212652,
@@ -274,16 +274,18 @@
         "gn:id":443335,
         "gp:id":20070417,
         "hasc:id":"UG.JI",
+        "iso:code":"UG-204",
         "iso:id":"UG-204",
         "qs_pg:id":237423,
         "unlc:id":"UG-204",
         "wd:id":"Q983748"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"71831a53c2daf36ad5584568ff35a1b6",
+    "wof:geomhash":"927ed03cd1e1a6029fc923ad619decf1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -300,7 +302,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877013,
+    "wof:lastmodified":1695884912,
     "wof:name":"Jinja",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/77/85679777.geojson
+++ b/data/856/797/77/85679777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087309,
-    "geom:area_square_m":1079227339.189071,
+    "geom:area_square_m":1079227339.189131,
     "geom:bbox":"33.729819,1.260694,34.230064,1.6525",
     "geom:latitude":1.476344,
     "geom:longitude":33.96055,
@@ -217,9 +217,11 @@
         "fips:code":"UG46",
         "gp:id":20070430,
         "hasc:id":"UG.QM",
+        "iso:code":"UG-208",
         "iso:id":"UG-208",
         "wd:id":"Q1151062"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092071937
     ],
@@ -227,7 +229,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c435c34f4928b497c71aec90fb554684",
+    "wof:geomhash":"d8a075d0b2567d56ee5ec8278c6dcb79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +246,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877014,
+    "wof:lastmodified":1695884913,
     "wof:name":"Kumi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/83/85679783.geojson
+++ b/data/856/797/83/85679783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.132081,
-    "geom:area_square_m":1632433469.435682,
+    "geom:area_square_m":1632433568.342323,
     "geom:bbox":"32.945725,1.463323,33.45198,2.055798",
     "geom:latitude":1.760821,
     "geom:longitude":33.221815,
@@ -280,16 +280,18 @@
         "gn:id":448215,
         "gp:id":24550743,
         "hasc:id":"UG.KD",
+        "iso:code":"UG-213",
         "iso:id":"UG-213",
         "qs_pg:id":1154616,
         "unlc:id":"UG-213",
         "wd:id":"Q1229906"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de6263ce4fc0887c4c7200eefb920dab",
+    "wof:geomhash":"e92380ef6f06914dc52f75090de1f716",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877014,
+    "wof:lastmodified":1695884913,
     "wof:name":"Kaberamaido",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/87/85679787.geojson
+++ b/data/856/797/87/85679787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138657,
-    "geom:area_square_m":1714259703.700755,
+    "geom:area_square_m":1714260340.831646,
     "geom:bbox":"32.693996,0.5075,33.083691,1.47762",
     "geom:latitude":0.976593,
     "geom:longitude":32.890352,
@@ -298,16 +298,18 @@
         "gn:id":448218,
         "gp:id":24550742,
         "hasc:id":"UG.KY",
+        "iso:code":"UG-112",
         "iso:id":"UG-112",
         "qs_pg:id":1154614,
         "unlc:id":"UG-112",
         "wd:id":"Q1207391"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bebe25d1fc3dcfa5142616e05721725",
+    "wof:geomhash":"6ef604d9068eea83fc13d94fb225e624",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877014,
+    "wof:lastmodified":1695884912,
     "wof:name":"Kayunga",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/89/85679789.geojson
+++ b/data/856/797/89/85679789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08294,
-    "geom:area_square_m":1025497080.194116,
+    "geom:area_square_m":1025496709.759397,
     "geom:bbox":"33.361537,0.446296,33.684071,0.911201",
     "geom:latitude":0.692303,
     "geom:longitude":33.525252,
@@ -224,14 +224,16 @@
         "fips:code":"UGA3",
         "gp:id":20070449,
         "hasc:id":"UG.IC",
+        "iso:code":"UG-203",
         "iso:id":"UG-203",
         "wd:id":"Q1229869"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"172ede16486b50e2bbc964b0bf9df0c3",
+    "wof:geomhash":"34d936a4c0e7b68920ed91a40e65c620",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -248,7 +250,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877013,
+    "wof:lastmodified":1695884913,
     "wof:name":"Iganga",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/95/85679795.geojson
+++ b/data/856/797/95/85679795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126561,
-    "geom:area_square_m":1564737872.604279,
+    "geom:area_square_m":1564737412.623984,
     "geom:bbox":"32.92713,0.657229,33.305464,1.227779",
     "geom:latitude":0.942574,
     "geom:longitude":33.103087,
@@ -217,14 +217,16 @@
         "fips:code":"UGA4",
         "gp:id":20070422,
         "hasc:id":"UG.QU",
+        "iso:code":"UG-205",
         "iso:id":"UG-205",
         "wd:id":"Q164474"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05b457de1cf15778aa792b05947dc692",
+    "wof:geomhash":"95fadd3f983a3d12ba6ce8996e141f35",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -241,7 +243,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877013,
+    "wof:lastmodified":1695884912,
     "wof:name":"Kamuli",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/797/99/85679799.geojson
+++ b/data/856/797/99/85679799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142972,
-    "geom:area_square_m":1767165246.972468,
+    "geom:area_square_m":1767165412.505271,
     "geom:bbox":"32.314389,1.438016,32.999266,1.839348",
     "geom:latitude":1.622029,
     "geom:longitude":32.73803,
@@ -283,16 +283,18 @@
         "gn:id":7056275,
         "gp:id":56190195,
         "hasc:id":"UG.MD",
+        "iso:code":"UG-107",
         "iso:id":"UG-107",
         "qs_pg:id":1096346,
         "unlc:id":"UG-314",
         "wd:id":"Q1318822"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c372ac17f7e0428aabce070e27be88d9",
+    "wof:geomhash":"1ce86edb9b9646793aa08272319bc739",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877014,
+    "wof:lastmodified":1695884913,
     "wof:name":"Amolatar",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/03/85679803.geojson
+++ b/data/856/798/03/85679803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070571,
-    "geom:area_square_m":872468603.412932,
+    "geom:area_square_m":872468920.966627,
     "geom:bbox":"33.335299,0.870099,33.636001,1.293475",
     "geom:latitude":1.070524,
     "geom:longitude":33.482625,
@@ -282,15 +282,17 @@
         "gn:id":7056287,
         "gp:id":56190214,
         "hasc:id":"UG.RO",
+        "iso:code":"UG-220",
         "iso:id":"UG-220",
         "qs_pg:id":176847,
         "wd:id":"Q1375859"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"018d4c871b4caa3a9de967a730495c34",
+    "wof:geomhash":"f679efdd8fe46a2fae69d06bde95c43f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877022,
+    "wof:lastmodified":1695884914,
     "wof:name":"Kaliro",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/07/85679807.geojson
+++ b/data/856/798/07/85679807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066187,
-    "geom:area_square_m":818319789.671664,
+    "geom:area_square_m":818319844.823926,
     "geom:bbox":"33.53946,0.686461,33.847693,1.09136",
     "geom:latitude":0.87154,
     "geom:longitude":33.680527,
@@ -181,15 +181,17 @@
         "gn:id":234069,
         "gp:id":-56190214,
         "hasc:id":"UG.BK",
+        "iso:code":"UG-222",
         "iso:id":"UG-222",
         "unlc:id":"UG-222",
         "wd:id":"Q6272234"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"08bb7625ec78ebf45e5eb120ff1a2933",
+    "wof:geomhash":"6651974c3b4e5eb31311819281bf3c62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -206,7 +208,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877024,
+    "wof:lastmodified":1695884915,
     "wof:name":"Namutumba",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/13/85679813.geojson
+++ b/data/856/798/13/85679813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114826,
-    "geom:area_square_m":1419168011.311129,
+    "geom:area_square_m":1419168011.311097,
     "geom:bbox":"33.395973,1.55864,33.814237,2.023329",
     "geom:latitude":1.774512,
     "geom:longitude":33.590272,
@@ -213,9 +213,11 @@
         "fips:code":"UG95",
         "gp:id":20070447,
         "hasc:id":"UG.ST",
+        "iso:code":"UG-211",
         "iso:id":"UG-211",
         "wd:id":"Q1091337"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092074055
     ],
@@ -223,7 +225,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c8e77894b49234a88d8527b2fdeb2944",
+    "wof:geomhash":"4a6602ed470f013d9eb0dc4d41a4503f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -240,7 +242,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877027,
+    "wof:lastmodified":1695884915,
     "wof:name":"Soroti",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/17/85679817.geojson
+++ b/data/856/798/17/85679817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.336753,
-    "geom:area_square_m":4163872907.30478,
+    "geom:area_square_m":4163872527.440723,
     "geom:bbox":"32.504904,-1.0,32.982756,0.859145",
     "geom:latitude":0.005774,
     "geom:longitude":32.786214,
@@ -219,14 +219,16 @@
         "fips:code":"UG90",
         "gp:id":20070438,
         "hasc:id":"UG.MV",
+        "iso:code":"UG-108",
         "iso:id":"UG-108",
         "wd:id":"Q1151066"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8bd0432971778afd298c8c6689533842",
+    "wof:geomhash":"9ed4cb841c88b8cd5d572e3c303b92bc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -243,7 +245,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877023,
+    "wof:lastmodified":1695884914,
     "wof:name":"Mukono",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/19/85679819.geojson
+++ b/data/856/798/19/85679819.geojson
@@ -202,8 +202,10 @@
     "wof:concordances":{
         "gp:id":20070441,
         "hasc:id":"UG.PS",
+        "iso:code":"UG-210",
         "wd:id":"Q1375843"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
@@ -225,7 +227,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884914,
     "wof:name":"Pallisa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/23/85679823.geojson
+++ b/data/856/798/23/85679823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.188398,
-    "geom:area_square_m":2329575450.763263,
+    "geom:area_square_m":2329575622.280384,
     "geom:bbox":"31.01221,-0.342884,31.598039,0.238413",
     "geom:latitude":-0.022941,
     "geom:longitude":31.339276,
@@ -280,16 +280,18 @@
         "gn:id":443787,
         "gp:id":20070450,
         "hasc:id":"UG.SE",
+        "iso:code":"UG-111",
         "iso:id":"UG-111",
         "qs_pg:id":1109540,
         "unlc:id":"UG-111",
         "wd:id":"Q976883"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"426555e15c69dbba0a3478f4876308f1",
+    "wof:geomhash":"47a7f016f7f18a75e0f48590fa2f4263",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877026,
+    "wof:lastmodified":1695884915,
     "wof:name":"Sembabule",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/27/85679827.geojson
+++ b/data/856/798/27/85679827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123619,
-    "geom:area_square_m":1528568264.289762,
+    "geom:area_square_m":1528568078.007027,
     "geom:bbox":"31.871132,-0.15234,32.426883,0.408258",
     "geom:latitude":0.069946,
     "geom:longitude":32.158024,
@@ -280,14 +280,16 @@
         "gn:id":233709,
         "gp:id":-20070436,
         "hasc:id":"UG.MJ",
+        "iso:code":"UG-106",
         "iso:id":"UG-106",
         "wd:id":"Q1362109"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6dd20dae4bc6bf84c351bbc99e2d238",
+    "wof:geomhash":"96846e4483f8c6dec50411471441a56e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -304,7 +306,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877022,
+    "wof:lastmodified":1695884914,
     "wof:name":"Mpigi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/33/85679833.geojson
+++ b/data/856/798/33/85679833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25157,
-    "geom:area_square_m":3105757069.482615,
+    "geom:area_square_m":3105757069.482581,
     "geom:bbox":"31.400014,2.882042,32.063424,3.592536",
     "geom:latitude":3.228636,
     "geom:longitude":31.76873,
@@ -289,11 +289,13 @@
         "gn:id":443782,
         "gp:id":20070445,
         "hasc:id":"UG.AD",
+        "iso:code":"UG-301",
         "iso:id":"UG-301",
         "qs_pg:id":59521,
         "unlc:id":"UG-301",
         "wd:id":"Q1229734"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092070471
     ],
@@ -301,7 +303,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b558454f300f29926afb09aba36a9d36",
+    "wof:geomhash":"d363a7909c92398ea102496e4a68afc0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877022,
+    "wof:lastmodified":1695884914,
     "wof:name":"Adjumani",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/37/85679837.geojson
+++ b/data/856/798/37/85679837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.262463,
-    "geom:area_square_m":3241305922.711082,
+    "geom:area_square_m":3241304956.246646,
     "geom:bbox":"30.768817,2.543134,31.534144,3.193216",
     "geom:latitude":2.877234,
     "geom:longitude":31.126342,
@@ -213,15 +213,17 @@
         "fips:code":"UGA1",
         "gp:id":20070412,
         "hasc:id":"UG.AX",
+        "iso:code":"UG-303",
         "iso:id":"UG-303",
         "qs_pg:id":237422,
         "wd:id":"Q1229758"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46b02cc16368b231f05910d855e64343",
+    "wof:geomhash":"9040b80d2c830d45e801e711ba484a4b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -238,7 +240,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877025,
+    "wof:lastmodified":1695884915,
     "wof:name":"Arua",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/39/85679839.geojson
+++ b/data/856/798/39/85679839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060836,
-    "geom:area_square_m":750828238.912328,
+    "geom:area_square_m":750828238.911726,
     "geom:bbox":"30.848079,3.328859,31.099522,3.744319",
     "geom:latitude":3.52682,
     "geom:longitude":31.006857,
@@ -286,11 +286,13 @@
         "gn:id":7056289,
         "gp:id":56190212,
         "hasc:id":"UG.OK",
+        "iso:code":"UG-316",
         "iso:id":"UG-316",
         "qs_pg:id":176846,
         "unlc:id":"UG-316",
         "wd:id":"Q1318857"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092071795
     ],
@@ -298,7 +300,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f6f9463f7609ddc6f482943093ffa4b7",
+    "wof:geomhash":"7200aba8f48bb5a6be5318f3ccf16f2a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877025,
+    "wof:lastmodified":1695884915,
     "wof:name":"Koboko",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/43/85679843.geojson
+++ b/data/856/798/43/85679843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.156742,
-    "geom:area_square_m":1937007682.647549,
+    "geom:area_square_m":1937007991.146905,
     "geom:bbox":"31.11393,1.677701,31.612857,2.265025",
     "geom:latitude":1.962317,
     "geom:longitude":31.400864,
@@ -116,15 +116,17 @@
         "fips:code":"UGC5",
         "gp:id":20070432,
         "hasc:id":"UG.BL",
+        "iso:code":"UG-419",
         "iso:id":"UG-419",
         "unlc:id":"UG-419",
         "wd:id":"Q4996412"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"490b6b122b330a45d9245efd77a44166",
+    "wof:geomhash":"aafcf70d1197b6da6db9677b07e50e81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +143,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877024,
+    "wof:lastmodified":1695884915,
     "wof:name":"Buliisa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/49/85679849.geojson
+++ b/data/856/798/49/85679849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163229,
-    "geom:area_square_m":2016492652.842723,
+    "geom:area_square_m":2016492642.65528,
     "geom:bbox":"31.001006,2.156437,31.528983,2.779689",
     "geom:latitude":2.461008,
     "geom:longitude":31.275105,
@@ -285,14 +285,16 @@
         "gn:id":443360,
         "gp:id":-20070439,
         "hasc:id":"UG.NB",
+        "iso:code":"UG-310",
         "iso:id":"UG-310",
         "wd:id":"Q1375825"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2705d9814dd518bed554941c594e319",
+    "wof:geomhash":"86a05848ef499732cb01eda9cbb1d5e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877027,
+    "wof:lastmodified":1695884915,
     "wof:name":"Nebbi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/53/85679853.geojson
+++ b/data/856/798/53/85679853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.151071,
-    "geom:area_square_m":1864468630.514216,
+    "geom:area_square_m":1864468952.450271,
     "geom:bbox":"31.426361,3.152139,31.976439,3.836599",
     "geom:latitude":3.52982,
     "geom:longitude":31.669143,
@@ -277,16 +277,18 @@
         "gn:id":443357,
         "gp:id":20070444,
         "hasc:id":"UG.MY",
+        "iso:code":"UG-309",
         "iso:id":"UG-309",
         "qs_pg:id":1251709,
         "unlc:id":"UG-309",
         "wd:id":"Q2183668"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f6d13d04ab489cfb0c8ee9a8f8d868cd",
+    "wof:geomhash":"76de29f0ada66a88cafd997ac6fb0c81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877024,
+    "wof:lastmodified":1695884915,
     "wof:name":"Moyo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/57/85679857.geojson
+++ b/data/856/798/57/85679857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189314,
-    "geom:area_square_m":2336463427.384172,
+    "geom:area_square_m":2336463267.59639,
     "geom:bbox":"31.048842,3.181055,31.535183,3.79408",
     "geom:latitude":3.523409,
     "geom:longitude":31.28826,
@@ -283,16 +283,18 @@
         "gn:id":448225,
         "gp:id":24550739,
         "hasc:id":"UG.YU",
+        "iso:code":"UG-313",
         "iso:id":"UG-313",
         "qs_pg:id":1191261,
         "unlc:id":"UG-313",
         "wd:id":"Q1362587"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"946d6724e9c39d09e2e32b49f9342e1b",
+    "wof:geomhash":"021812af42cc156e5e63d57bcd3b9dcc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877021,
+    "wof:lastmodified":1695884914,
     "wof:name":"Yumbe",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/61/85679861.geojson
+++ b/data/856/798/61/85679861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127424,
-    "geom:area_square_m":1573172268.809086,
+    "geom:area_square_m":1573172554.733292,
     "geom:bbox":"30.801692,3.01284,31.4246,3.37199",
     "geom:latitude":3.195335,
     "geom:longitude":31.099377,
@@ -221,16 +221,18 @@
         "fips:code":"UGD7",
         "gp:id":20070412,
         "hasc:id":"UG.MH",
+        "iso:code":"UG-320",
         "iso:id":"UG-320",
         "qs_pg:id":237422,
         "unlc:id":"UG-320",
         "wd:id":"Q1229758"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ca5c95fd48afbdcfa09ea7df53538583",
+    "wof:geomhash":"509991a74c39ac868de2f3f4e63ae0a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -247,7 +249,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877021,
+    "wof:lastmodified":1695884914,
     "wof:name":"Maracha",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/67/85679867.geojson
+++ b/data/856/798/67/85679867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015971,
-    "geom:area_square_m":197478598.756169,
+    "geom:area_square_m":197478598.756182,
     "geom:bbox":"32.510269,0.218872,32.670175,0.408811",
     "geom:latitude":0.317657,
     "geom:longitude":32.596129,
@@ -283,11 +283,13 @@
         "gn:id":443339,
         "gp:id":20070421,
         "hasc:id":"UG.KM",
+        "iso:code":"UG-102",
         "iso:id":"UG-102",
         "qs_pg:id":327607,
         "unlc:id":"UG-102",
         "wd:id":"Q926417"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421173185
     ],
@@ -295,7 +297,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fceb944c329f6da3054aba31537aa349",
+    "wof:geomhash":"6095a2f61fb95c7114d320504965e116",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877022,
+    "wof:lastmodified":1695884914,
     "wof:name":"Kampala",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/71/85679871.geojson
+++ b/data/856/798/71/85679871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.132676,
-    "geom:area_square_m":1640382848.510879,
+    "geom:area_square_m":1640383032.139905,
     "geom:bbox":"31.647874,0.616175,32.212294,1.100861",
     "geom:latitude":0.846815,
     "geom:longitude":31.949424,
@@ -229,14 +229,16 @@
         "fips:code":"UG42",
         "gp:id":20070426,
         "hasc:id":"UG.QO",
+        "iso:code":"UG-103",
         "iso:id":"UG-103",
         "wd:id":"Q892064"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"93ebd3e6321904c2f9ba72d032bb042f",
+    "wof:geomhash":"07c9366da93264d531d03236343ce1ee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -253,7 +255,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877026,
+    "wof:lastmodified":1695884915,
     "wof:name":"Kiboga",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/75/85679875.geojson
+++ b/data/856/798/75/85679875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284989,
-    "geom:area_square_m":3522948591.536487,
+    "geom:area_square_m":3522948755.777161,
     "geom:bbox":"31.967119,0.961451,32.79975,1.678684",
     "geom:latitude":1.354819,
     "geom:longitude":32.424491,
@@ -283,16 +283,18 @@
         "gn:id":443786,
         "gp:id":20070452,
         "hasc:id":"UG.NA",
+        "iso:code":"UG-109",
         "iso:id":"UG-109",
         "qs_pg:id":1064705,
         "unlc:id":"UG-109",
         "wd:id":"Q976859"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09317d80c3f29eb3e232ade44ce3a617",
+    "wof:geomhash":"59ce49783da129649d8eac25765ebea0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877023,
+    "wof:lastmodified":1695884914,
     "wof:name":"Nakasongola",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/79/85679879.geojson
+++ b/data/856/798/79/85679879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.228401,
-    "geom:area_square_m":2824184719.182042,
+    "geom:area_square_m":2824184765.303842,
     "geom:bbox":"32.191712,-0.152084,32.687578,0.585758",
     "geom:latitude":0.222555,
     "geom:longitude":32.444701,
@@ -285,16 +285,18 @@
         "gn:id":448224,
         "gp:id":24550740,
         "hasc:id":"UG.WA",
+        "iso:code":"UG-113",
         "iso:id":"UG-113",
         "qs_pg:id":1196802,
         "unlc:id":"UG-113",
         "wd:id":"Q976848"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"498063a3d6e1c278a8e9ccf582e01cc2",
+    "wof:geomhash":"1a83b276069a96b203581ef8ab5a3e3d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -311,7 +313,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877026,
+    "wof:lastmodified":1695884915,
     "wof:name":"Wakiso",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/81/85679881.geojson
+++ b/data/856/798/81/85679881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180322,
-    "geom:area_square_m":2229476947.460784,
+    "geom:area_square_m":2229476902.892956,
     "geom:bbox":"32.317635,0.551348,32.795304,1.147684",
     "geom:latitude":0.831877,
     "geom:longitude":32.582229,
@@ -227,15 +227,17 @@
         "fips:code":"UGA9",
         "gp:id":20070453,
         "hasc:id":"UG.LW",
+        "iso:code":"UG-104",
         "iso:id":"UG-104",
         "qs_pg:id":1084703,
         "wd:id":"Q1364817"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eebb76d52464deb5338fa39783fc9fd1",
+    "wof:geomhash":"b7e059002f62ee9c96a11f67da40b760",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -252,7 +254,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877024,
+    "wof:lastmodified":1695884914,
     "wof:name":"Luweero",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/89/85679889.geojson
+++ b/data/856/798/89/85679889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.375407,
-    "geom:area_square_m":4641768215.047345,
+    "geom:area_square_m":4641768654.992034,
     "geom:bbox":"31.021724,0.164263,31.956955,0.868316",
     "geom:latitude":0.521567,
     "geom:longitude":31.533667,
@@ -289,16 +289,18 @@
         "gn:id":443358,
         "gp:id":20070437,
         "hasc:id":"UG.RR",
+        "iso:code":"UG-410",
         "iso:id":"UG-410",
         "qs_pg:id":1087222,
         "unlc:id":"UG-107",
         "wd:id":"Q891962"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"25dbec51af75b073259d542f39dda26a",
+    "wof:geomhash":"0913657eff62626a685b9c92be19e974",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877023,
+    "wof:lastmodified":1695884914,
     "wof:name":"Mubende",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/91/85679891.geojson
+++ b/data/856/798/91/85679891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128549,
-    "geom:area_square_m":1589477472.776849,
+    "geom:area_square_m":1589476826.862614,
     "geom:bbox":"31.802855,0.214137,32.267057,0.697595",
     "geom:latitude":0.445484,
     "geom:longitude":32.058911,
@@ -280,16 +280,18 @@
         "gn:id":7056293,
         "gp:id":56190215,
         "hasc:id":"UG.TY",
+        "iso:code":"UG-114",
         "iso:id":"UG-114",
         "qs_pg:id":923447,
         "unlc:id":"UG-114",
         "wd:id":"Q1230005"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7757f41ccda36f0d450130cfa5d9d339",
+    "wof:geomhash":"b7d79e628424a5774d561d37a01c1901",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877024,
+    "wof:lastmodified":1695884915,
     "wof:name":"Mityana",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/95/85679895.geojson
+++ b/data/856/798/95/85679895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.282415,
-    "geom:area_square_m":3491497476.316724,
+    "geom:area_square_m":3491497440.926296,
     "geom:bbox":"31.821762,0.537061,32.499465,1.470917",
     "geom:latitude":1.051444,
     "geom:longitude":32.168359,
@@ -125,16 +125,18 @@
         "fips:code":"UGD9",
         "gp:id":20070453,
         "hasc:id":"UG.NK",
+        "iso:code":"UG-115",
         "iso:id":"UG-115",
         "qs_pg:id":1084703,
         "unlc:id":"UG-115",
         "wd:id":"Q3529595"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46dda29f77516a7b7b8a47513c15e83f",
+    "wof:geomhash":"3cc6fb14de5239af348951b4949f3e5e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -151,7 +153,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877021,
+    "wof:lastmodified":1695884914,
     "wof:name":"Nakaseke",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/798/99/85679899.geojson
+++ b/data/856/798/99/85679899.geojson
@@ -202,8 +202,10 @@
     "wof:concordances":{
         "gp:id":20070428,
         "hasc:id":"UG.QT",
+        "iso:code":"UG-305",
         "wd:id":"Q500162"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
@@ -225,7 +227,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884915,
     "wof:name":"Kitgum",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/05/85679905.geojson
+++ b/data/856/799/05/85679905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.280869,
-    "geom:area_square_m":3468729441.711784,
+    "geom:area_square_m":3468729233.839375,
     "geom:bbox":"32.128427,2.452467,32.823856,3.302897",
     "geom:latitude":2.836529,
     "geom:longitude":32.429458,
@@ -269,15 +269,17 @@
         "gn:id":443331,
         "gp:id":20070415,
         "hasc:id":"UG.GL",
+        "iso:code":"UG-304",
         "iso:id":"UG-304",
         "qs_pg:id":1087215,
         "wd:id":"Q1028215"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"80c1a4533d1b0a8a30a74be6770881d4",
+    "wof:geomhash":"aae9e45094661d6cf683f2fd67c1dc4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -294,7 +296,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877016,
+    "wof:lastmodified":1695884913,
     "wof:name":"Gulu",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/09/85679909.geojson
+++ b/data/856/799/09/85679909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108149,
-    "geom:area_square_m":1336199922.181559,
+    "geom:area_square_m":1336200080.791464,
     "geom:bbox":"32.779248,2.012566,33.160888,2.654224",
     "geom:latitude":2.30282,
     "geom:longitude":32.967539,
@@ -279,14 +279,16 @@
         "gn:id":443349,
         "gp:id":-20070431,
         "hasc:id":"UG.LL",
+        "iso:code":"UG-307",
         "iso:id":"UG-307",
         "wd:id":"Q206519"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"817a3cb2e09d4a5c83066da750941b57",
+    "wof:geomhash":"84a1a88a7948d9a96fa8688bd561ba67",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877019,
+    "wof:lastmodified":1695884913,
     "wof:name":"Lira",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/13/85679913.geojson
+++ b/data/856/799/13/85679913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087389,
-    "geom:area_square_m":1079966403.121695,
+    "geom:area_square_m":1079966403.121692,
     "geom:bbox":"32.860566,1.707964,33.289156,2.111103",
     "geom:latitude":1.939567,
     "geom:longitude":33.077467,
@@ -277,11 +277,13 @@
         "gn:id":7056283,
         "gp:id":56190203,
         "hasc:id":"UG.DO",
+        "iso:code":"UG-318",
         "iso:id":"UG-318",
         "qs_pg:id":881332,
         "unlc:id":"UG-318",
         "wd:id":"Q1318872"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092070439
     ],
@@ -289,7 +291,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b085b6add576de7726a0b70bf84ea22",
+    "wof:geomhash":"7d1be84dcdaa4d9a5144f756073cbc11",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877020,
+    "wof:lastmodified":1695884914,
     "wof:name":"Dokolo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/17/85679917.geojson
+++ b/data/856/799/17/85679917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273688,
-    "geom:area_square_m":3379748844.679579,
+    "geom:area_square_m":3379748454.181743,
     "geom:bbox":"32.471596,2.531241,33.223165,3.241764",
     "geom:latitude":2.935463,
     "geom:longitude":32.871562,
@@ -178,14 +178,16 @@
         "fips:code":"UG92",
         "gp:id":24550736,
         "hasc:id":"UG.PR",
+        "iso:code":"UG-312",
         "iso:id":"UG-312",
         "wd:id":"Q1230035"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"db6fee0bdd9225e3da3ba1448b63084c",
+    "wof:geomhash":"2c98879b1bb752553929564c14f97e7b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +204,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877017,
+    "wof:lastmodified":1695884913,
     "wof:name":"Pader",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/21/85679921.geojson
+++ b/data/856/799/21/85679921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319319,
-    "geom:area_square_m":3946569589.892904,
+    "geom:area_square_m":3946569623.59031,
     "geom:bbox":"31.367959,1.32623,32.090828,2.300243",
     "geom:latitude":1.746435,
     "geom:longitude":31.711529,
@@ -229,14 +229,16 @@
         "fips:code":"UG50",
         "gp:id":20070432,
         "hasc:id":"UG.MZ",
+        "iso:code":"UG-409",
         "iso:id":"UG-409",
         "wd:id":"Q1032238"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"73c4bacd69050e29cc4183ecf41ecddb",
+    "wof:geomhash":"cd05ed11153bfa0d7e04b2361b73e67a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -253,7 +255,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877017,
+    "wof:lastmodified":1695884913,
     "wof:name":"Masindi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/27/85679927.geojson
+++ b/data/856/799/27/85679927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178312,
-    "geom:area_square_m":2202964916.945148,
+    "geom:area_square_m":2202964916.945081,
     "geom:bbox":"32.227142,2.074984,32.822472,2.623293",
     "geom:latitude":2.371004,
     "geom:longitude":32.486473,
@@ -277,11 +277,13 @@
         "gn:id":7056295,
         "gp:id":56190213,
         "hasc:id":"UG.OY",
+        "iso:code":"UG-321",
         "iso:id":"UG-321",
         "qs_pg:id":923445,
         "unlc:id":"UG-321",
         "wd:id":"Q1318833"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092073449
     ],
@@ -289,7 +291,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ebe4d60201750bafcf548dac8931e705",
+    "wof:geomhash":"b0530ff45aa412bc85aa2ebc999ef4bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877016,
+    "wof:lastmodified":1695884913,
     "wof:name":"Oyam",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/29/85679929.geojson
+++ b/data/856/799/29/85679929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06695,
-    "geom:area_square_m":827792247.932716,
+    "geom:area_square_m":827792060.844037,
     "geom:bbox":"29.911667,0.4026,30.204903,0.895043",
     "geom:latitude":0.698243,
     "geom:longitude":30.056901,
@@ -276,15 +276,17 @@
         "gn:id":443329,
         "gp:id":20070413,
         "hasc:id":"UG.BX",
+        "iso:code":"UG-401",
         "iso:id":"UG-401",
         "qs_pg:id":1087213,
         "wd:id":"Q1362129"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c50877da6ff6ee5891ac212ffdf593a",
+    "wof:geomhash":"1f532145764d9a8c166ed12904de1150",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -301,7 +303,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877017,
+    "wof:lastmodified":1695884913,
     "wof:name":"Bundibugyo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/33/85679933.geojson
+++ b/data/856/799/33/85679933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.459993,
-    "geom:area_square_m":5686095558.480229,
+    "geom:area_square_m":5686095211.953453,
     "geom:bbox":"30.540681,1.073639,31.588371,1.852395",
     "geom:latitude":1.433539,
     "geom:longitude":31.065309,
@@ -292,16 +292,18 @@
         "gn:id":443332,
         "gp:id":20070416,
         "hasc:id":"UG.HO",
+        "iso:code":"UG-403",
         "iso:id":"UG-403",
         "qs_pg:id":890566,
         "unlc:id":"UG-403",
         "wd:id":"Q1186535"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13c7ce74475d41eadd9dade0ef5ff2be",
+    "wof:geomhash":"fc5ec65c9bc85b537ac5118aa6ddb568",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877016,
+    "wof:lastmodified":1695884913,
     "wof:name":"Hoima",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/39/85679939.geojson
+++ b/data/856/799/39/85679939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147419,
-    "geom:area_square_m":1822761500.184726,
+    "geom:area_square_m":1822761210.071279,
     "geom:bbox":"29.987005,0.268254,30.56079,0.971601",
     "geom:latitude":0.599851,
     "geom:longitude":30.288995,
@@ -273,15 +273,17 @@
         "gn:id":443337,
         "gp:id":-20070419,
         "hasc:id":"UG.BR",
+        "iso:code":"UG-405",
         "iso:id":"UG-405",
         "unlc:id":"UG-405",
         "wd:id":"Q1229910"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ea2613f0a83a8ac5257df6d6bfa4452",
+    "wof:geomhash":"3c079d16e3bf924e21f6919e00bbb234",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -298,7 +300,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877019,
+    "wof:lastmodified":1695884913,
     "wof:name":"Kabarole",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/43/85679943.geojson
+++ b/data/856/799/43/85679943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190927,
-    "geom:area_square_m":2360690154.669457,
+    "geom:area_square_m":2360690344.336449,
     "geom:bbox":"30.396393,0.349975,30.924679,0.939208",
     "geom:latitude":0.659423,
     "geom:longitude":30.661955,
@@ -279,14 +279,16 @@
         "gn:id":226116,
         "gp:id":-24550734,
         "hasc:id":"UG.QJ",
+        "iso:code":"UG-415",
         "iso:id":"UG-415",
         "wd:id":"Q1318815"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"283d237b744849a37165d87c5c5afc8c",
+    "wof:geomhash":"e0e09de8a3578cc470c53a01d5b17fe6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877018,
+    "wof:lastmodified":1695884913,
     "wof:name":"Kyenjojo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/47/85679947.geojson
+++ b/data/856/799/47/85679947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.356641,
-    "geom:area_square_m":4409311744.87023,
+    "geom:area_square_m":4409312615.194487,
     "geom:bbox":"30.535746,0.634543,31.528013,1.221907",
     "geom:latitude":0.950132,
     "geom:longitude":31.063269,
@@ -272,16 +272,18 @@
         "gn:id":443343,
         "gp:id":20070425,
         "hasc:id":"UG.KI",
+        "iso:code":"UG-407",
         "iso:id":"UG-407",
         "qs_pg:id":13419,
         "unlc:id":"UG-407",
         "wd:id":"Q604966"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d05f83faf83bea4e781af275b4258703",
+    "wof:geomhash":"8d8661dbc8dbfffe45964c3fe5c27c02",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -298,7 +300,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877020,
+    "wof:lastmodified":1695884914,
     "wof:name":"Kibale",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/51/85679951.geojson
+++ b/data/856/799/51/85679951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028786,
-    "geom:area_square_m":355846730.627284,
+    "geom:area_square_m":355846886.422293,
     "geom:bbox":"34.303603,1.197292,34.537415,1.477866",
     "geom:latitude":1.351863,
     "geom:longitude":34.422162,
@@ -213,14 +213,16 @@
         "fips:code":"UGA5",
         "gp:id":20070423,
         "hasc:id":"UG.QP",
+        "iso:code":"UG-206",
         "iso:id":"UG-206",
         "wd:id":"Q1229921"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9bfa690a130124e26ccabe79d6cebd80",
+    "wof:geomhash":"5aaacef95a7f34e14803439d54ce7be5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -237,7 +239,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877016,
+    "wof:lastmodified":1695884913,
     "wof:name":"Kapchorwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/57/85679957.geojson
+++ b/data/856/799/57/85679957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043696,
-    "geom:area_square_m":540182272.434596,
+    "geom:area_square_m":540182004.310255,
     "geom:bbox":"34.551741,1.104697,34.831583,1.410567",
     "geom:latitude":1.272786,
     "geom:longitude":34.683352,
@@ -264,15 +264,17 @@
         "gn:id":7056296,
         "gp:id":-20070423,
         "hasc:id":"UG.BW",
+        "iso:code":"UG-218",
         "iso:id":"UG-218",
         "unlc:id":"UG-218",
         "wd:id":"Q4987159"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f85e92aa29a43972559895ed55dc1709",
+    "wof:geomhash":"7f24270edc2c316ca4a5955e6ebb25c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -289,7 +291,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877015,
+    "wof:lastmodified":1695884913,
     "wof:name":"Bukwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/61/85679961.geojson
+++ b/data/856/799/61/85679961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036252,
-    "geom:area_square_m":448172273.789602,
+    "geom:area_square_m":448172201.159421,
     "geom:bbox":"34.17828,1.086904,34.527208,1.289348",
     "geom:latitude":1.172689,
     "geom:longitude":34.331562,
@@ -222,14 +222,16 @@
         "fips:code":"UG94",
         "gp:id":24550737,
         "hasc:id":"UG.SK",
+        "iso:code":"UG-215",
         "iso:id":"UG-215",
         "wd:id":"Q1375835"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64af64566f3a1d735e4584c6a3451d21",
+    "wof:geomhash":"d1725356808f5a9b2a076c645a0b535e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -246,7 +248,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877015,
+    "wof:lastmodified":1695884913,
     "wof:name":"Sironko",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/65/85679965.geojson
+++ b/data/856/799/65/85679965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042018,
-    "geom:area_square_m":519478780.226804,
+    "geom:area_square_m":519479041.771416,
     "geom:bbox":"34.083465,0.836244,34.336,1.170767",
     "geom:latitude":1.021772,
     "geom:longitude":34.197501,
@@ -212,15 +212,17 @@
         "fips:code":"UGB1",
         "gp:id":20070433,
         "hasc:id":"UG.ME",
+        "iso:code":"UG-209",
         "iso:id":"UG-209",
         "qs_pg:id":1087218,
         "wd:id":"Q581822"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ca065a76872383b0975c1a99fbd83326",
+    "wof:geomhash":"bbcf9c328fba8ec59c271e1ad1b1159b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -237,7 +239,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877019,
+    "wof:lastmodified":1695884914,
     "wof:name":"Mbale",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/69/85679969.geojson
+++ b/data/856/799/69/85679969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049808,
-    "geom:area_square_m":615812699.339592,
+    "geom:area_square_m":615812630.028143,
     "geom:bbox":"34.181888,0.753533,34.492231,1.027696",
     "geom:latitude":0.889976,
     "geom:longitude":34.34159,
@@ -115,16 +115,18 @@
         "fips:code":"UGD6",
         "gp:id":20070433,
         "hasc:id":"UG.MW",
+        "iso:code":"UG-221",
         "iso:id":"UG-221",
         "qs_pg:id":1087218,
         "unlc:id":"UG-221",
         "wd:id":"Q6272973"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6368bbbda81784907cfada3d4bfb5170",
+    "wof:geomhash":"82556f52dd3afddfefdd6fdf65d753d1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +143,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877015,
+    "wof:lastmodified":1695884913,
     "wof:name":"Manafwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/75/85679975.geojson
+++ b/data/856/799/75/85679975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.465553,
-    "geom:area_square_m":5756424750.975471,
+    "geom:area_square_m":5756425429.134373,
     "geom:bbox":"33.611489,-1.0,33.984247,0.734886",
     "geom:latitude":-0.161494,
     "geom:longitude":33.797596,
@@ -243,15 +243,17 @@
         "gn:id":443783,
         "gp:id":99,
         "hasc:id":"UG.BI",
+        "iso:code":"UG-201",
         "iso:id":"UG-201",
         "unlc:id":"UG-201",
         "wd:id":"Q1229798"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42cb548dc7c2aab76864b6d86fe5e663",
+    "wof:geomhash":"c7388fb9e08efe8d795b478a8db4c6c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -268,7 +270,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877018,
+    "wof:lastmodified":1695884913,
     "wof:name":"Bugiri",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/79/85679979.geojson
+++ b/data/856/799/79/85679979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062672,
-    "geom:area_square_m":774928373.007268,
+    "geom:area_square_m":774927988.842409,
     "geom:bbox":"33.87894,0.190005,34.138574,0.594877",
     "geom:latitude":0.413669,
     "geom:longitude":34.005336,
@@ -282,15 +282,17 @@
         "gn:id":443784,
         "gp:id":20070454,
         "hasc:id":"UG.BU",
+        "iso:code":"UG-202",
         "iso:id":"UG-202",
         "qs_pg:id":44634,
         "wd:id":"Q1229800"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cb4d89428ab760c56e443ae075aedaf2",
+    "wof:geomhash":"01a9e31ce1641c356df6421f6b189d81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877020,
+    "wof:lastmodified":1695884914,
     "wof:name":"Busia",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/81/85679981.geojson
+++ b/data/856/799/81/85679981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053154,
-    "geom:area_square_m":657186124.674035,
+    "geom:area_square_m":657185734.584053,
     "geom:bbox":"33.760049,0.688474,34.128163,1.045139",
     "geom:latitude":0.885572,
     "geom:longitude":33.931937,
@@ -280,16 +280,18 @@
         "gn:id":7056282,
         "gp:id":56190199,
         "hasc:id":"UG.BJ",
+        "iso:code":"UG-219",
         "iso:id":"UG-219",
         "qs_pg:id":1112930,
         "unlc:id":"UG-219",
         "wd:id":"Q1375755"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5195fe5fea25f531c40880c4690d0c77",
+    "wof:geomhash":"39eec8415b7c65115e9114ff195a8ede",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877018,
+    "wof:lastmodified":1695884913,
     "wof:name":"Butaleja",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/85/85679985.geojson
+++ b/data/856/799/85/85679985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.278737,
-    "geom:area_square_m":3446520721.935114,
+    "geom:area_square_m":3446521000.632713,
     "geom:bbox":"33.272855,-1.0,33.708808,0.606885",
     "geom:latitude":-0.090174,
     "geom:longitude":33.550692,
@@ -283,16 +283,18 @@
         "gn:id":448220,
         "gp:id":24550732,
         "hasc:id":"UG.MG",
+        "iso:code":"UG-214",
         "iso:id":"UG-214",
         "qs_pg:id":1000598,
         "unlc:id":"UG-244",
         "wd:id":"Q1364824"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"206f3552c2c86af6ddb978633825c746",
+    "wof:geomhash":"c2e458af158f037aa95592eaaa1ba8ff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877020,
+    "wof:lastmodified":1695884914,
     "wof:name":"Mayuge",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/89/85679989.geojson
+++ b/data/856/799/89/85679989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097969,
-    "geom:area_square_m":1211305143.987849,
+    "geom:area_square_m":1211305402.721913,
     "geom:bbox":"33.877404,0.578064,34.313723,0.907421",
     "geom:latitude":0.727463,
     "geom:longitude":34.081988,
@@ -273,16 +273,18 @@
         "gn:id":443366,
         "gp:id":20070455,
         "hasc:id":"UG.TR",
+        "iso:code":"UG-212",
         "iso:id":"UG-212",
         "qs_pg:id":44633,
         "unlc:id":"UG-212",
         "wd:id":"Q1186541"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1cb9dd1ba0238d344ca72bf2b0aebd2",
+    "wof:geomhash":"21dc44b6301b4dc1bac3470f439adf56",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +301,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877017,
+    "wof:lastmodified":1695884913,
     "wof:name":"Tororo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/95/85679995.geojson
+++ b/data/856/799/95/85679995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.197564,
-    "geom:area_square_m":2441533950.966856,
+    "geom:area_square_m":2441534159.848349,
     "geom:bbox":"33.808598,1.6375,34.224282,2.307206",
     "geom:latitude":1.925083,
     "geom:longitude":34.037306,
@@ -231,14 +231,16 @@
         "gn:id":443785,
         "gp:id":-56190194,
         "hasc:id":"UG.KK",
+        "iso:code":"UG-207",
         "iso:id":"UG-207",
         "wd:id":"Q2544864"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df991102cf266b7d2a6c49a683d15371",
+    "wof:geomhash":"1689b27fc76c884c66dd49a035b28733",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -255,7 +257,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877015,
+    "wof:lastmodified":1695884913,
     "wof:name":"Katakwi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/799/99/85679999.geojson
+++ b/data/856/799/99/85679999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301259,
-    "geom:area_square_m":3719888999.009286,
+    "geom:area_square_m":3719889281.408997,
     "geom:bbox":"33.547887,2.620498,34.393643,3.441848",
     "geom:latitude":3.034859,
     "geom:longitude":33.980937,
@@ -217,15 +217,17 @@
         "fips:code":"UGA7",
         "gp:id":20070429,
         "hasc:id":"UG.KF",
+        "iso:code":"UG-306",
         "iso:id":"UG-306",
         "qs_pg:id":902960,
         "wd:id":"Q1318843"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a9ef70b0632643ef45e5eb447fb343c1",
+    "wof:geomhash":"2bdf453c965ac53a61654f06aa143d14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -242,7 +244,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877019,
+    "wof:lastmodified":1695884914,
     "wof:name":"Kotido",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/03/85680003.geojson
+++ b/data/856/800/03/85680003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.210446,
-    "geom:area_square_m":2600442712.752269,
+    "geom:area_square_m":2600442792.113088,
     "geom:bbox":"33.347131,1.727259,33.910535,2.417766",
     "geom:latitude":2.106761,
     "geom:longitude":33.686136,
@@ -189,15 +189,17 @@
         "gn:id":7056276,
         "gp:id":20070446,
         "hasc:id":"UG.PS",
+        "iso:code":"UG-210",
         "iso:id":"UG-210",
         "qs_pg:id":1251710,
         "wd:id":"Q4749005"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c06d97a27a44b9f1fd4439153951096",
+    "wof:geomhash":"752b32227267a14df0648b9cb7eca634",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -214,7 +216,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877030,
+    "wof:lastmodified":1695884916,
     "wof:name":"Amuria",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/07/85680007.geojson
+++ b/data/856/800/07/85680007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.580089,
-    "geom:area_square_m":7158626091.393545,
+    "geom:area_square_m":7158626046.063964,
     "geom:bbox":"33.515867,3.0825,34.558862,4.218628",
     "geom:latitude":3.607628,
     "geom:longitude":34.032052,
@@ -176,16 +176,18 @@
         "fips:code":"UGD1",
         "gp:id":20070429,
         "hasc:id":"UG.AB",
+        "iso:code":"UG-315",
         "iso:id":"UG-315",
         "qs_pg:id":902960,
         "unlc:id":"UG-315",
         "wd:id":"Q6272909"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"66be08a8fe89b0f33c5c7091a6652cfd",
+    "wof:geomhash":"e01f7e2d2728451b2445c02c9dcf17f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +204,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877033,
+    "wof:lastmodified":1695884916,
     "wof:name":"Kaabong",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/13/85680013.geojson
+++ b/data/856/800/13/85680013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191688,
-    "geom:area_square_m":2367524190.822859,
+    "geom:area_square_m":2367524074.025268,
     "geom:bbox":"33.521563,2.456144,34.036864,3.152992",
     "geom:latitude":2.750613,
     "geom:longitude":33.72987,
@@ -160,15 +160,17 @@
         "gn:id":7056273,
         "gp:id":-20070429,
         "hasc:id":"UG.IB",
+        "iso:code":"UG-416",
         "iso:id":"UG-416",
         "unlc:id":"UG-317",
         "wd:id":"Q16249258"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9db09cc0dc2e4e50773a0596699907a4",
+    "wof:geomhash":"a51ab1b4e66b000be569e8db2559570b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -185,7 +187,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501851,
+    "wof:lastmodified":1695884917,
     "wof:name":"Abim",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/17/85680017.geojson
+++ b/data/856/800/17/85680017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287684,
-    "geom:area_square_m":3553434784.68484,
+    "geom:area_square_m":3553435080.7843,
     "geom:bbox":"34.280556,2.127289,34.955515,3.108778",
     "geom:latitude":2.651873,
     "geom:longitude":34.630802,
@@ -220,14 +220,16 @@
         "fips:code":"UG88",
         "gp:id":20070435,
         "hasc:id":"UG.MX",
+        "iso:code":"UG-308",
         "iso:id":"UG-308",
         "wd:id":"Q1375850"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b5796873819275c3ac638a010dab9c2",
+    "wof:geomhash":"7e699d6096d12b1f03f9f6db53f867b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +246,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877032,
+    "wof:lastmodified":1695884916,
     "wof:name":"Moroto",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/21/85680021.geojson
+++ b/data/856/800/21/85680021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.341436,
-    "geom:area_square_m":4219607834.120102,
+    "geom:area_square_m":4219608139.438002,
     "geom:bbox":"34.220736,1.549415,34.871664,2.441376",
     "geom:latitude":1.888519,
     "geom:longitude":34.563028,
@@ -214,14 +214,16 @@
         "fips:code":"UG91",
         "gp:id":24550738,
         "hasc:id":"UG.NI",
+        "iso:code":"UG-311",
         "iso:id":"UG-311",
         "wd:id":"Q1375853"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bf76b6ac47b9f2ef0d75be51bd1c4e2",
+    "wof:geomhash":"0cded4a03e016c9d266c337e2e46fa12",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -238,7 +240,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877032,
+    "wof:lastmodified":1695884916,
     "wof:name":"Nakapiripirit",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/25/85680025.geojson
+++ b/data/856/800/25/85680025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330029,
-    "geom:area_square_m":4080500750.83954,
+    "geom:area_square_m":4080501348.501643,
     "geom:bbox":"31.09011,-1.001481,31.999626,-0.427443",
     "geom:latitude":-0.765224,
     "geom:longitude":31.519263,
@@ -274,15 +274,17 @@
         "gn:id":443363,
         "gp:id":-20070442,
         "hasc:id":"UG.RI",
+        "iso:code":"UG-110",
         "iso:id":"UG-110",
         "unlc:id":"UG-110",
         "wd:id":"Q976873"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eec8be5cb680a6b5a3d7b9ae79ce2242",
+    "wof:geomhash":"95bdce4a1e98ab01aa70ff0717c86989",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +301,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877035,
+    "wof:lastmodified":1695884917,
     "wof:name":"Rakai",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/31/85680031.geojson
+++ b/data/856/800/31/85680031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165184,
-    "geom:area_square_m":2042453239.315929,
+    "geom:area_square_m":2042453216.946911,
     "geom:bbox":"31.656975,-0.815933,32.060639,-0.1494",
     "geom:latitude":-0.499378,
     "geom:longitude":31.865913,
@@ -223,14 +223,16 @@
         "fips:code":"UG71",
         "gp:id":20070451,
         "hasc:id":"UG.MQ",
+        "iso:code":"UG-105",
         "iso:id":"UG-105",
         "wd:id":"Q1032233"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"06a492437ee0ece83ec775bbb359dd48",
+    "wof:geomhash":"a43cccd20278dc7ee22a8f9b4b24ff5e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -247,7 +249,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877033,
+    "wof:lastmodified":1695884917,
     "wof:name":"Masaka",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/35/85680035.geojson
+++ b/data/856/800/35/85680035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076908,
-    "geom:area_square_m":950951833.578126,
+    "geom:area_square_m":950951824.843582,
     "geom:bbox":"29.907281,-0.661409,30.311674,-0.301286",
     "geom:latitude":-0.476845,
     "geom:longitude":30.132426,
@@ -270,14 +270,16 @@
         "gn:id":443330,
         "gp:id":-20070414,
         "hasc:id":"UG.BC",
+        "iso:code":"UG-402",
         "iso:id":"UG-402",
         "wd:id":"Q1229797"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7cfcddafd9cdb711638d073d5897095b",
+    "wof:geomhash":"9fa0e6dc2f808f187ad800c123e1a384",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -294,7 +296,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877030,
+    "wof:lastmodified":1695884916,
     "wof:name":"Bushenyi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/37/85680037.geojson
+++ b/data/856/800/37/85680037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273136,
-    "geom:area_square_m":3377352235.442867,
+    "geom:area_square_m":3377352138.446846,
     "geom:bbox":"29.704074,-0.208464,30.296103,0.484098",
     "geom:latitude":0.12057,
     "geom:longitude":30.002018,
@@ -270,16 +270,18 @@
         "gn:id":443342,
         "gp:id":20070424,
         "hasc:id":"UG.KS",
+        "iso:code":"UG-406",
         "iso:id":"UG-406",
         "qs_pg:id":425216,
         "unlc:id":"UG-406",
         "wd:id":"Q1229919"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"44f528ed79385f1c78745f3cc99cb295",
+    "wof:geomhash":"c9ff32833a46dadd974a0bbd22f629bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -296,7 +298,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877033,
+    "wof:lastmodified":1695884917,
     "wof:name":"Kasese",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/41/85680041.geojson
+++ b/data/856/800/41/85680041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195863,
-    "geom:area_square_m":2421860123.025031,
+    "geom:area_square_m":2421860510.399091,
     "geom:bbox":"30.212436,-0.180958,30.858636,0.57806",
     "geom:latitude":0.228163,
     "geom:longitude":30.493018,
@@ -277,16 +277,18 @@
         "gn:id":448216,
         "gp:id":24550735,
         "hasc:id":"UG.KE",
+        "iso:code":"UG-413",
         "iso:id":"UG-413",
         "qs_pg:id":221884,
         "unlc:id":"UG-413",
         "wd:id":"Q1318806"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"15a37b5f9c2837d51620377d871c34f7",
+    "wof:geomhash":"d26f3d5eab251696d9bc9d98d4abd372",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877034,
+    "wof:lastmodified":1695884917,
     "wof:name":"Kamwenge",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/47/85680047.geojson
+++ b/data/856/800/47/85680047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078326,
-    "geom:area_square_m":968517471.883643,
+    "geom:area_square_m":968517471.883617,
     "geom:bbox":"30.246556,-0.286396,30.638789,0.164335",
     "geom:latitude":-0.076533,
     "geom:longitude":30.488663,
@@ -280,11 +280,13 @@
         "gn:id":7056284,
         "gp:id":56190204,
         "hasc:id":"UG.AM",
+        "iso:code":"UG-216",
         "iso:id":"UG-216",
         "qs_pg:id":1112932,
         "unlc:id":"UG-416",
         "wd:id":"Q1318877"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092070677
     ],
@@ -292,7 +294,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dab6473f4033a70efc8497d19964596",
+    "wof:geomhash":"56d6bea9b230821da147ee1677151737",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877035,
+    "wof:lastmodified":1695884917,
     "wof:name":"Ibanda",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/51/85680051.geojson
+++ b/data/856/800/51/85680051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218179,
-    "geom:area_square_m":2697525873.613016,
+    "geom:area_square_m":2697525544.562714,
     "geom:bbox":"30.479261,-1.07618,31.270272,-0.599968",
     "geom:latitude":-0.851862,
     "geom:longitude":30.876213,
@@ -280,16 +280,18 @@
         "gn:id":7056285,
         "gp:id":56190210,
         "hasc:id":"UG.NG",
+        "iso:code":"UG-417",
         "iso:id":"UG-417",
         "qs_pg:id":1112934,
         "unlc:id":"UG-417",
         "wd:id":"Q1318887"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9dd0dc039e2529f347c572cba3541e77",
+    "wof:geomhash":"2f23f12178094455c13330ba86e30933",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877031,
+    "wof:lastmodified":1695884916,
     "wof:name":"Isingiro",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/59/85680059.geojson
+++ b/data/856/800/59/85680059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166866,
-    "geom:area_square_m":2063049865.297683,
+    "geom:area_square_m":2063049924.316817,
     "geom:bbox":"30.027645,-1.192797,30.632699,-0.719256",
     "geom:latitude":-0.93896,
     "geom:longitude":30.275873,
@@ -286,16 +286,18 @@
         "gn:id":443361,
         "gp:id":20070440,
         "hasc:id":"UG.NT",
+        "iso:code":"UG-411",
         "iso:id":"UG-411",
         "qs_pg:id":967618,
         "unlc:id":"UG-411",
         "wd:id":"Q204642"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4a05cbee6d575f3c5fae346825ae8116",
+    "wof:geomhash":"5689e609a05eeb0341c2a9fcd6ef086e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877030,
+    "wof:lastmodified":1695884916,
     "wof:name":"Ntungamo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/61/85680061.geojson
+++ b/data/856/800/61/85680061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124022,
-    "geom:area_square_m":1533434269.962476,
+    "geom:area_square_m":1533434466.509053,
     "geom:bbox":"29.676543,-1.057898,30.074627,-0.336339",
     "geom:latitude":-0.70342,
     "geom:longitude":29.888427,
@@ -280,16 +280,18 @@
         "gn:id":443364,
         "gp:id":20070443,
         "hasc:id":"UG.RK",
+        "iso:code":"UG-412",
         "iso:id":"UG-412",
         "qs_pg:id":1251712,
         "unlc:id":"UG-412",
         "wd:id":"Q289419"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f4f9371b22034663925ad407fd2ebbd4",
+    "wof:geomhash":"86f7e7ebeda5849a61f7c9094b845917",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877029,
+    "wof:lastmodified":1695884916,
     "wof:name":"Rukungiri",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/69/85680069.geojson
+++ b/data/856/800/69/85680069.geojson
@@ -196,9 +196,11 @@
     "wof:concordances":{
         "gp:id":20070434,
         "hasc:id":"UG.RR",
+        "iso:code":"UG-410",
         "qs_pg:id":1087219,
         "wd:id":"Q1091595"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
@@ -220,7 +222,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884916,
     "wof:name":"Mbarara",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/73/85680073.geojson
+++ b/data/856/800/73/85680073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142029,
-    "geom:area_square_m":1755811156.321579,
+    "geom:area_square_m":1755810744.559586,
     "geom:bbox":"29.72708,-1.481483,30.300882,-0.987693",
     "geom:latitude":-1.221386,
     "geom:longitude":29.976497,
@@ -282,16 +282,18 @@
         "gn:id":443336,
         "gp:id":20070418,
         "hasc:id":"UG.KA",
+        "iso:code":"UG-404",
         "iso:id":"UG-404",
         "qs_pg:id":237424,
         "unlc:id":"UG-404",
         "wd:id":"Q3526470"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"060a7ef57ed4c18eb3c4e648c7f8f085",
+    "wof:geomhash":"9ae047fade05579014063737ba81cd36",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -308,7 +310,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877032,
+    "wof:lastmodified":1695884916,
     "wof:name":"Kabale",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/75/85680075.geojson
+++ b/data/856/800/75/85680075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059293,
-    "geom:area_square_m":733001418.787954,
+    "geom:area_square_m":733001367.289429,
     "geom:bbox":"29.573558,-1.389214,29.821324,-1.007282",
     "geom:latitude":-1.217197,
     "geom:longitude":29.681477,
@@ -234,16 +234,18 @@
         "gn:id":443345,
         "gp:id":20070427,
         "hasc:id":"UG.KR",
+        "iso:code":"UG-408",
         "iso:id":"UG-408",
         "qs_pg:id":902977,
         "unlc:id":"UG-408",
         "wd:id":"Q580538"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e5bc7b5a829a514067a62d79fb3fd31",
+    "wof:geomhash":"8286e489bf833ebf8f76a701a60de736",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -260,7 +262,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877032,
+    "wof:lastmodified":1695884916,
     "wof:name":"Kisoro",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/79/85680079.geojson
+++ b/data/856/800/79/85680079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106626,
-    "geom:area_square_m":1318314176.814352,
+    "geom:area_square_m":1318313375.366724,
     "geom:bbox":"29.581914,-1.07624,29.90249,-0.34019",
     "geom:latitude":-0.808943,
     "geom:longitude":29.726351,
@@ -279,16 +279,18 @@
         "gn:id":448217,
         "gp:id":24550733,
         "hasc:id":"UG.UU",
+        "iso:code":"UG-414",
         "iso:id":"UG-414",
         "qs_pg:id":888235,
         "unlc:id":"UG-414",
         "wd:id":"Q1032245"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ffde1f795e769178764ff6af91c035fb",
+    "wof:geomhash":"2df6f12f92a1955e1691f8813651e246",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -305,7 +307,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877034,
+    "wof:lastmodified":1695884917,
     "wof:name":"Kanungu",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/85/85680085.geojson
+++ b/data/856/800/85/85680085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073345,
-    "geom:area_square_m":906041513.166461,
+    "geom:area_square_m":906040813.264979,
     "geom:bbox":"30.740743,2.329511,31.070584,2.713084",
     "geom:latitude":2.520594,
     "geom:longitude":30.895999,
@@ -345,15 +345,17 @@
         "gn:id":8030563,
         "gp:id":20070439,
         "hasc:id":"UG.ZO",
+        "iso:code":"UG-331",
         "iso:id":"UG-331",
         "qs_pg:id":1063351,
         "wd:id":"Q8073799"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0c336f8a18745599800e0ffc6410f3c2",
+    "wof:geomhash":"82926e027abd84a07199f040e4e6b990",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -370,7 +372,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501851,
+    "wof:lastmodified":1695884917,
     "wof:name":"Zombo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/89/85680089.geojson
+++ b/data/856/800/89/85680089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058634,
-    "geom:area_square_m":724765712.162372,
+    "geom:area_square_m":724765902.470407,
     "geom:bbox":"33.555351,1.312037,33.900281,1.68514",
     "geom:latitude":1.499049,
     "geom:longitude":33.753482,
@@ -172,15 +172,17 @@
         "gn:id":8030570,
         "gp:id":-20070430,
         "hasc:id":"UG.NR",
+        "iso:code":"UG-231",
         "iso:id":"UG-231",
         "unlc:id":"UG-231",
         "wd:id":"Q6693037"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c117e6b7c6c462f08b88f50bd8819e4",
+    "wof:geomhash":"d21c312252f1704948d4d4906397fb61",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -197,7 +199,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877031,
+    "wof:lastmodified":1695884916,
     "wof:name":"Ngora",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/95/85680095.geojson
+++ b/data/856/800/95/85680095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085368,
-    "geom:area_square_m":1055295036.62089,
+    "geom:area_square_m":1055295156.548799,
     "geom:bbox":"33.917256,1.160422,34.274772,1.582569",
     "geom:latitude":1.364517,
     "geom:longitude":34.123377,
@@ -185,15 +185,17 @@
         "gn:id":234411,
         "gp:id":-20070430,
         "hasc:id":"UG.BE",
+        "iso:code":"UG-224",
         "iso:id":"UG-224",
         "unlc:id":"UG-224",
         "wd:id":"Q4986830"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"282d818621114efd5149f49f3c4c0bc0",
+    "wof:geomhash":"819612c28001165a304e5d4643613ad7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -210,7 +212,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877030,
+    "wof:lastmodified":1695884916,
     "wof:name":"Bukedea",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/800/97/85680097.geojson
+++ b/data/856/800/97/85680097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052787,
-    "geom:area_square_m":652654532.712703,
+    "geom:area_square_m":652654497.540283,
     "geom:bbox":"33.21807,0.563123,33.432286,1.078908",
     "geom:latitude":0.807275,
     "geom:longitude":33.337687,
@@ -221,15 +221,17 @@
         "fips:code":"UGG4",
         "gp:id":20070449,
         "hasc:id":"UG.LK",
+        "iso:code":"UG-229",
         "iso:id":"UG-229",
         "unlc:id":"UG-229",
         "wd:id":"Q1229869"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"659c3db0a2be236249d89180932cbf3c",
+    "wof:geomhash":"bf6d8ceb8fbed8269fc0c83f4c3e2aae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -246,7 +248,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877033,
+    "wof:lastmodified":1695884917,
     "wof:name":"Luuka",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/03/85680103.geojson
+++ b/data/856/801/03/85680103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15269,
-    "geom:area_square_m":1887582373.689764,
+    "geom:area_square_m":1887582071.041809,
     "geom:bbox":"32.820667,0.987438,33.439334,1.4839",
     "geom:latitude":1.2643,
     "geom:longitude":33.140939,
@@ -116,15 +116,17 @@
         "fips:code":"UGF3",
         "gp:id":20070422,
         "hasc:id":"UG.BY",
+        "iso:code":"UG-226",
         "iso:id":"UG-226",
         "unlc:id":"UG-226",
         "wd:id":"Q5003357"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"90fbdacc995d38524eec112438005b50",
+    "wof:geomhash":"9985abdacc5682e55eaedee732bfce12",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +143,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877036,
+    "wof:lastmodified":1695884917,
     "wof:name":"Buyende",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/07/85680107.geojson
+++ b/data/856/801/07/85680107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033363,
-    "geom:area_square_m":412470673.63417,
+    "geom:area_square_m":412470673.63412,
     "geom:bbox":"33.86294,0.9375,34.12558,1.193936",
     "geom:latitude":1.062625,
     "geom:longitude":33.987985,
@@ -277,11 +277,13 @@
         "gn:id":7056279,
         "gp:id":56190197,
         "hasc:id":"UG.BD",
+        "iso:code":"UG-217",
         "iso:id":"UG-217",
         "qs_pg:id":1136337,
         "unlc:id":"UG-217",
         "wd:id":"Q1362085"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1092068817
     ],
@@ -289,7 +291,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f810a482587d4f6abdda051e935e8303",
+    "wof:geomhash":"4aa1f5078d0315b6d4b7efba7275be8b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877038,
+    "wof:lastmodified":1695884918,
     "wof:name":"Budaka",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/11/85680111.geojson
+++ b/data/856/801/11/85680111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039869,
-    "geom:area_square_m":492902620.656837,
+    "geom:area_square_m":492902403.393279,
     "geom:bbox":"33.626366,0.945987,33.935964,1.172168",
     "geom:latitude":1.056519,
     "geom:longitude":33.800399,
@@ -218,15 +218,17 @@
         "fips:code":"UGF6",
         "gp:id":20070441,
         "hasc:id":"UG.QB",
+        "iso:code":"UG-227",
         "iso:id":"UG-227",
         "unlc:id":"UG-227",
         "wd:id":"Q1375843"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53f27932a34384bf25b10cf926af05d1",
+    "wof:geomhash":"c91e8c5687d1e63d6ed0451347814f74",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -243,7 +245,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877037,
+    "wof:lastmodified":1695884917,
     "wof:name":"Kibuku",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/19/85680119.geojson
+++ b/data/856/801/19/85680119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159716,
-    "geom:area_square_m":1974253762.329165,
+    "geom:area_square_m":1974254157.732935,
     "geom:bbox":"33.015309,1.31191,33.707362,1.676257",
     "geom:latitude":1.491131,
     "geom:longitude":33.371983,
@@ -113,15 +113,17 @@
         "fips:code":"UGH5",
         "gp:id":20070447,
         "hasc:id":"UG.SX",
+        "iso:code":"UG-232",
         "iso:id":"UG-232",
         "unlc:id":"UG-232",
         "wd:id":"Q6693290"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3f36fede4737e94f1315933508488041",
+    "wof:geomhash":"59163fe3b7998d8cb10d8505444e62eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +140,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877037,
+    "wof:lastmodified":1695884917,
     "wof:name":"Serere",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/21/85680121.geojson
+++ b/data/856/801/21/85680121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117526,
-    "geom:area_square_m":1453211421.719638,
+    "geom:area_square_m":1453211808.989029,
     "geom:bbox":"32.8625,0.050942,33.290897,0.557231",
     "geom:latitude":0.308801,
     "geom:longitude":33.039719,
@@ -187,15 +187,17 @@
         "gn:id":8030577,
         "gp:id":-20070438,
         "hasc:id":"UG.BZ",
+        "iso:code":"UG-117",
         "iso:id":"UG-117",
         "unlc:id":"UG-117",
         "wd:id":"Q4986374"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"87c1f9a550f015f45230fa1607629c91",
+    "wof:geomhash":"d4bfcd81844bb3963772239c3148dd6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -212,7 +214,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877037,
+    "wof:lastmodified":1695884917,
     "wof:name":"Buikwe",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/25/85680125.geojson
+++ b/data/856/801/25/85680125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.775506,
-    "geom:area_square_m":9588871928.970747,
+    "geom:area_square_m":9588871640.776743,
     "geom:bbox":"32.872383,-1.0,33.522632,0.358205",
     "geom:latitude":-0.3939,
     "geom:longitude":33.207618,
@@ -221,15 +221,17 @@
         "fips:code":"UGF2",
         "gp:id":20070438,
         "hasc:id":"UG.BV",
+        "iso:code":"UG-120",
         "iso:id":"UG-120",
         "unlc:id":"UG-120",
         "wd:id":"Q1151066"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"708fd23e5bf3d61886ca4817887a5767",
+    "wof:geomhash":"e5777d942b111b0eb7134c56e92944cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -246,7 +248,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877039,
+    "wof:lastmodified":1695884918,
     "wof:name":"Buvuma",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/31/85680131.geojson
+++ b/data/856/801/31/85680131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033132,
-    "geom:area_square_m":409681178.49339,
+    "geom:area_square_m":409681495.480619,
     "geom:bbox":"31.810752,0.009841,32.302924,0.319325",
     "geom:latitude":0.156344,
     "geom:longitude":32.073533,
@@ -144,14 +144,16 @@
         "gn:id":7910136,
         "gp:id":-20070436,
         "hasc:id":"UG.BT",
+        "iso:code":"UG-119",
         "iso:id":"UG-119",
         "unlc:id":"UG-119"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"85e8b97158f0ab49072d857f515a2bee",
+    "wof:geomhash":"893aa3b99bf4439321d3d3533e227912",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -168,7 +170,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501854,
+    "wof:lastmodified":1695884918,
     "wof:name":"Butambala",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/33/85680133.geojson
+++ b/data/856/801/33/85680133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13623,
-    "geom:area_square_m":1684496492.753439,
+    "geom:area_square_m":1684496678.731743,
     "geom:bbox":"31.308255,0.03959,32.15463,0.369961",
     "geom:latitude":0.198913,
     "geom:longitude":31.701546,
@@ -199,15 +199,17 @@
         "gn:id":8030578,
         "gp:id":-20070436,
         "hasc:id":"UG.GM",
+        "iso:code":"UG-121",
         "iso:id":"UG-121",
         "unlc:id":"UG-121",
         "wd:id":"Q1011712"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"99ccc4e0135db9fc703ff7eade38a219",
+    "wof:geomhash":"883fbd91f2b0a3407753e3e8ffb826e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -224,7 +226,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877036,
+    "wof:lastmodified":1695884538,
     "wof:name":"Gomba",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/39/85680139.geojson
+++ b/data/856/801/39/85680139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.294599,
-    "geom:area_square_m":3637577708.723544,
+    "geom:area_square_m":3637578007.792194,
     "geom:bbox":"31.35942,2.678124,32.363439,3.587165",
     "geom:latitude":3.052668,
     "geom:longitude":31.972441,
@@ -125,15 +125,17 @@
         "fips:code":"UGB9",
         "gp:id":20070415,
         "hasc:id":"UG.AY",
+        "iso:code":"UG-319",
         "iso:id":"UG-319",
         "unlc:id":"UG-319",
         "wd:id":"Q4749014"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6dc471d1324f3f5df95fbc15b460d64d",
+    "wof:geomhash":"88750507090a45fcac3ed661c6678a88",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +152,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877038,
+    "wof:lastmodified":1695884918,
     "wof:name":"Amuru",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/47/85680147.geojson
+++ b/data/856/801/47/85680147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451029,
-    "geom:area_square_m":5566369309.670201,
+    "geom:area_square_m":5566368819.335387,
     "geom:bbox":"32.196063,3.154338,33.328949,3.890723",
     "geom:latitude":3.545778,
     "geom:longitude":32.728544,
@@ -217,14 +217,16 @@
         "fips:code":"UGG3",
         "gp:id":20070428,
         "hasc:id":"UG.LM",
+        "iso:code":"UG-327",
         "iso:id":"UG-327",
         "wd:id":"Q500162"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6496a31c98fa17e26735a1e50076a61a",
+    "wof:geomhash":"97f87093643b98e9eb1a1411be595492",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -241,7 +243,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877039,
+    "wof:lastmodified":1695884918,
     "wof:name":"Lamwo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/51/85680151.geojson
+++ b/data/856/801/51/85680151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264712,
-    "geom:area_square_m":3271427687.296329,
+    "geom:area_square_m":3271427274.217074,
     "geom:bbox":"32.091214,1.612633,32.958544,2.222548",
     "geom:latitude":1.891782,
     "geom:longitude":32.564414,
@@ -276,14 +276,16 @@
         "gn:id":443327,
         "gp:id":-20070411,
         "hasc:id":"UG.AQ",
+        "iso:code":"UG-302",
         "iso:id":"UG-302",
         "wd:id":"Q1229750"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e3c3dcc560d63d446bb6d0c2454c2d4",
+    "wof:geomhash":"41c8ebe0ed890a5209af23170fe273a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -300,7 +302,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877036,
+    "wof:lastmodified":1695884917,
     "wof:name":"Apac",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/57/85680157.geojson
+++ b/data/856/801/57/85680157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087183,
-    "geom:area_square_m":1077170487.766553,
+    "geom:area_square_m":1077170338.850291,
     "geom:bbox":"32.577029,2.081672,32.92423,2.52221",
     "geom:latitude":2.29551,
     "geom:longitude":32.766649,
@@ -174,15 +174,17 @@
         "gn:id":8030565,
         "gp:id":20070411,
         "hasc:id":"UG.QL",
+        "iso:code":"UG-326",
         "iso:id":"UG-326",
         "qs_pg:id":364493,
         "wd:id":"Q3108824"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d0acec3d22e9154451c06e35ac14851",
+    "wof:geomhash":"aacff7418b24779e1b992fbb0f0d4ba4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -199,7 +201,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877036,
+    "wof:lastmodified":1695884917,
     "wof:name":"Kole",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/61/85680161.geojson
+++ b/data/856/801/61/85680161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124455,
-    "geom:area_square_m":1537698637.607126,
+    "geom:area_square_m":1537698902.651697,
     "geom:bbox":"32.977927,2.030501,33.547109,2.508548",
     "geom:latitude":2.270422,
     "geom:longitude":33.255838,
@@ -180,14 +180,16 @@
         "gn:id":8030568,
         "gp:id":-20070431,
         "hasc:id":"UG.AL",
+        "iso:code":"UG-323",
         "iso:id":"UG-323",
         "wd:id":"Q4714068"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2c44364afc599133d088cc7aaf9fdf9",
+    "wof:geomhash":"2a26e2de5ecf4fcc26de4bf50f029f78",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -204,7 +206,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877035,
+    "wof:lastmodified":1695884917,
     "wof:name":"Alebtong",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/65/85680165.geojson
+++ b/data/856/801/65/85680165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125543,
-    "geom:area_square_m":1550909081.055912,
+    "geom:area_square_m":1550908708.806415,
     "geom:bbox":"33.003565,2.324381,33.657565,2.630011",
     "geom:latitude":2.481116,
     "geom:longitude":33.362605,
@@ -165,14 +165,16 @@
         "gn:id":8030567,
         "gp:id":-20070431,
         "hasc:id":"UG.OT",
+        "iso:code":"UG-330",
         "iso:id":"UG-330",
         "wd:id":"Q6696899"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"765278574a6228f6978b98dea063f688",
+    "wof:geomhash":"d912aabd59aff2ece8fe36cc4d18087a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -189,7 +191,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501854,
+    "wof:lastmodified":1695884918,
     "wof:name":"Otuke",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/69/85680169.geojson
+++ b/data/856/801/69/85680169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284323,
-    "geom:area_square_m":3511154128.84523,
+    "geom:area_square_m":3511154312.494285,
     "geom:bbox":"33.012407,2.588645,33.604402,3.307785",
     "geom:latitude":2.912029,
     "geom:longitude":33.345997,
@@ -109,14 +109,16 @@
         "fips:code":"UGE3",
         "gp:id":24550736,
         "hasc:id":"UG.AG",
+        "iso:code":"UG-322",
         "iso:id":"UG-322",
         "wd:id":"Q4690976"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e844e88408b542ab5aa88f493bab3817",
+    "wof:geomhash":"60a3818648f7b48c62a1875b2e4125ba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +135,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501852,
+    "wof:lastmodified":1695884917,
     "wof:name":"Agago",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/75/85680175.geojson
+++ b/data/856/801/75/85680175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.294974,
-    "geom:area_square_m":3645114091.966056,
+    "geom:area_square_m":3645114085.801593,
     "geom:bbox":"31.745,1.615876,32.363027,2.369175",
     "geom:latitude":2.02597,
     "geom:longitude":32.040112,
@@ -172,16 +172,18 @@
         "gn:id":8030564,
         "gp:id":20070432,
         "hasc:id":"UG.QD",
+        "iso:code":"UG-420",
         "iso:id":"UG-420",
         "qs_pg:id":1087217,
         "unlc:id":"UG-420",
         "wd:id":"Q6699373"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0285b99dc40169f8e79356bd8a0f374e",
+    "wof:geomhash":"1a4c7c9994c72eca7dc091917a124932",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -198,7 +200,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877037,
+    "wof:lastmodified":1695884918,
     "wof:name":"Kiryandongo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/79/85680179.geojson
+++ b/data/856/801/79/85680179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11212,
-    "geom:area_square_m":1386162534.169973,
+    "geom:area_square_m":1386162239.315245,
     "geom:bbox":"30.152506,0.721136,30.551756,1.288697",
     "geom:latitude":1.012384,
     "geom:longitude":30.363292,
@@ -163,15 +163,17 @@
         "gn:id":8030583,
         "gp:id":-20070413,
         "hasc:id":"UG.NO",
+        "iso:code":"UG-423",
         "iso:id":"UG-423",
         "unlc:id":"UG-423",
         "wd:id":"Q16896010"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd80834a1a06c0d3e413d938d7e18cea",
+    "wof:geomhash":"b26fb0d44f167170c308ea4c4aec44a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -188,7 +190,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877038,
+    "wof:lastmodified":1695884918,
     "wof:name":"Ntoroko",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/83/85680183.geojson
+++ b/data/856/801/83/85680183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14196,
-    "geom:area_square_m":1755300069.047555,
+    "geom:area_square_m":1755299437.22859,
     "geom:bbox":"30.769549,0.194327,31.2575,0.770878",
     "geom:latitude":0.453613,
     "geom:longitude":31.001247,
@@ -175,16 +175,18 @@
         "gn:id":8030581,
         "gp:id":24550734,
         "hasc:id":"UG.QG",
+        "iso:code":"UG-421",
         "iso:id":"UG-421",
         "qs_pg:id":970547,
         "unlc:id":"UG-421",
         "wd:id":"Q6450897"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47913941328c65ea447cd6b82e8fe8d8",
+    "wof:geomhash":"c45da0dc8015fd8db23d8bf00a69cd9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -201,7 +203,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877039,
+    "wof:lastmodified":1695884918,
     "wof:name":"Kyegegwa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/87/85680187.geojson
+++ b/data/856/801/87/85680187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069256,
-    "geom:area_square_m":856100285.728967,
+    "geom:area_square_m":856100620.365945,
     "geom:bbox":"34.406713,1.099311,34.756701,1.6025",
     "geom:latitude":1.431976,
     "geom:longitude":34.573335,
@@ -146,14 +146,16 @@
         "gn:id":8030574,
         "gp:id":-20070423,
         "hasc:id":"UG.QW",
+        "iso:code":"UG-228",
         "iso:id":"UG-228",
         "unlc:id":"UG-228"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f46a758f2c3721da3e71d50d394966c",
+    "wof:geomhash":"98f01f96377afd2988da42baa2d5f9ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -170,7 +172,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501853,
+    "wof:lastmodified":1695884918,
     "wof:name":"Kween",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/801/95/85680195.geojson
+++ b/data/856/801/95/85680195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053139,
-    "geom:area_square_m":656879255.314364,
+    "geom:area_square_m":656878802.657206,
     "geom:bbox":"34.226202,1.151863,34.537286,1.569735",
     "geom:latitude":1.381292,
     "geom:longitude":34.352176,
@@ -105,15 +105,17 @@
         "fips:code":"UGE9",
         "gp:id":24550737,
         "hasc:id":"UG.BB",
+        "iso:code":"UG-225",
         "iso:id":"UG-225",
         "unlc:id":"UG-225",
         "wd:id":"Q4987203"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"24d8cfe3ebbf8c2d73b32e354aede2ca",
+    "wof:geomhash":"dee6a420d302c617aa7198d9a533e102",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +132,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501852,
+    "wof:lastmodified":1695884917,
     "wof:name":"Bulambuli",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/01/85680201.geojson
+++ b/data/856/802/01/85680201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404667,
-    "geom:area_square_m":4999362749.248236,
+    "geom:area_square_m":4999362885.820486,
     "geom:bbox":"33.630168,1.885623,34.590829,2.907413",
     "geom:latitude":2.399602,
     "geom:longitude":34.221374,
@@ -220,14 +220,16 @@
         "fips:code":"UGG8",
         "gp:id":20070435,
         "hasc:id":"UG.NQ",
+        "iso:code":"UG-328",
         "iso:id":"UG-328",
         "wd:id":"Q1375850"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c842ff904148248bd6a9f3c9d44f9c4",
+    "wof:geomhash":"d9160a4d85879b6ae730f2be64c92ded",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +246,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877028,
+    "wof:lastmodified":1695884915,
     "wof:name":"Napak",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/09/85680209.geojson
+++ b/data/856/802/09/85680209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134828,
-    "geom:area_square_m":1666326020.069568,
+    "geom:area_square_m":1666326041.560728,
     "geom:bbox":"34.622266,1.367992,35.033049,2.28813",
     "geom:latitude":1.810133,
     "geom:longitude":34.88034,
@@ -121,14 +121,16 @@
         "fips:code":"UGE5",
         "gp:id":24550738,
         "hasc:id":"UG.AZ",
+        "iso:code":"UG-324",
         "iso:id":"UG-324",
         "wd:id":"Q4748920"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f6e1f30ccfffd2dba91d4692da2b386",
+    "wof:geomhash":"d03931d8a967a6d7d4534d399204b310",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -145,7 +147,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877028,
+    "wof:lastmodified":1695884916,
     "wof:name":"Amudat",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/11/85680211.geojson
+++ b/data/856/802/11/85680211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095458,
-    "geom:area_square_m":1180327317.283346,
+    "geom:area_square_m":1180327196.258834,
     "geom:bbox":"31.167211,-0.594832,31.826952,-0.230656",
     "geom:latitude":-0.402521,
     "geom:longitude":31.45977,
@@ -169,15 +169,17 @@
         "gn:id":8030580,
         "gp:id":-20070451,
         "hasc:id":"UG.LE",
+        "iso:code":"UG-124",
         "iso:id":"UG-124",
         "unlc:id":"UG-124",
         "wd:id":"Q6687528"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"067c02d2d61a74ea3d2ddacae80853cc",
+    "wof:geomhash":"36f7b01ad5a1bdbbf777758cfa12b20f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -194,7 +196,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877027,
+    "wof:lastmodified":1695884915,
     "wof:name":"Lwengo",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/15/85680215.geojson
+++ b/data/856/802/15/85680215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072258,
-    "geom:area_square_m":893470804.734289,
+    "geom:area_square_m":893470874.972294,
     "geom:bbox":"31.0675,-0.491767,31.3325,-0.026808",
     "geom:latitude":-0.217102,
     "geom:longitude":31.189565,
@@ -175,15 +175,17 @@
         "gn:id":7056290,
         "gp:id":-20070451,
         "hasc:id":"UG.LY",
+        "iso:code":"UG-116",
         "iso:id":"UG-116",
         "unlc:id":"UG-116",
         "wd:id":"Q6687695"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0c35885030556553d0aa26cad5d9d90",
+    "wof:geomhash":"4252fa2e2105b1abed06b54d32647743",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -200,7 +202,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877029,
+    "wof:lastmodified":1695884916,
     "wof:name":"Lyantonde",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/19/85680219.geojson
+++ b/data/856/802/19/85680219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04887,
-    "geom:area_square_m":604284400.008141,
+    "geom:area_square_m":604284548.847847,
     "geom:bbox":"31.533323,-0.304324,31.722838,0.052877",
     "geom:latitude":-0.12697,
     "geom:longitude":31.627286,
@@ -174,14 +174,16 @@
         "gn:id":8030579,
         "gp:id":-20070451,
         "hasc:id":"UG.BM",
+        "iso:code":"UG-118",
         "iso:id":"UG-118",
         "wd:id":"Q4986998"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2040797445b1c7ef3e8309eb4a4633a",
+    "wof:geomhash":"5146b82178105151103572e110033bf6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -198,7 +200,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877028,
+    "wof:lastmodified":1695884916,
     "wof:name":"Bukomansimbi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/23/85680223.geojson
+++ b/data/856/802/23/85680223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068132,
-    "geom:area_square_m":842460446.517677,
+    "geom:area_square_m":842460135.29731,
     "geom:bbox":"31.647709,-0.274129,31.99159,0.079369",
     "geom:latitude":-0.099669,
     "geom:longitude":31.802012,
@@ -340,15 +340,17 @@
         "gn:id":7910134,
         "gp:id":-20070451,
         "hasc:id":"UG.QA",
+        "iso:code":"UG-122",
         "iso:id":"UG-122",
         "unlc:id":"UG-122",
         "wd:id":"Q15822537"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"08be9152cb7947027cf318b34d9caaa3",
+    "wof:geomhash":"8e9a015a846fa91f18f6cdb520bcb372",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -365,7 +367,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501847,
+    "wof:lastmodified":1695884916,
     "wof:name":"Kalungu",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/29/85680229.geojson
+++ b/data/856/802/29/85680229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106873,
-    "geom:area_square_m":1321489389.102592,
+    "geom:area_square_m":1321489191.153162,
     "geom:bbox":"29.676924,-0.4475,30.287321,-0.06289",
     "geom:latitude":-0.246709,
     "geom:longitude":29.98537,
@@ -110,15 +110,17 @@
         "fips:code":"UGH4",
         "gp:id":20070414,
         "hasc:id":"UG.RZ",
+        "iso:code":"UG-424",
         "iso:id":"UG-424",
         "unlc:id":"UG-424",
         "wd:id":"Q6700100"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1d4cea7dd53108633eb0c0fb489e4706",
+    "wof:geomhash":"ad60217921428e90b613b08435ee049e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +137,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877028,
+    "wof:lastmodified":1695884915,
     "wof:name":"Rubirizi",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/33/85680233.geojson
+++ b/data/856/802/33/85680233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044092,
-    "geom:area_square_m":545167887.417001,
+    "geom:area_square_m":545167780.452743,
     "geom:bbox":"29.885485,-0.776341,30.160008,-0.437224",
     "geom:latitude":-0.621644,
     "geom:longitude":30.021619,
@@ -178,15 +178,17 @@
         "gn:id":8030586,
         "gp:id":-20070414,
         "hasc:id":"UG.MM",
+        "iso:code":"UG-422",
         "iso:id":"UG-422",
         "unlc:id":"UG-422",
         "wd:id":"Q6699878"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"595309962e6974b8071c25d4e8b705d8",
+    "wof:geomhash":"7f1f9c36cd3b5dc2996815c35fbb8019",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -203,7 +205,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877027,
+    "wof:lastmodified":1695884915,
     "wof:name":"Mitooma",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/37/85680237.geojson
+++ b/data/856/802/37/85680237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056771,
-    "geom:area_square_m":701948180.276792,
+    "geom:area_square_m":701948032.964989,
     "geom:bbox":"30.116694,-0.762059,30.477506,-0.423225",
     "geom:latitude":-0.601639,
     "geom:longitude":30.325648,
@@ -156,14 +156,16 @@
         "gn:id":8030587,
         "gp:id":-20070414,
         "hasc:id":"UG.SH",
+        "iso:code":"UG-425",
         "iso:id":"UG-425",
         "unlc:id":"UG-425"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d3c5cccd7235ff87927e4d1fa9a39a54",
+    "wof:geomhash":"72101efe057d2befde70296faeac3d80",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -180,7 +182,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501846,
+    "wof:lastmodified":1695884916,
     "wof:name":"Sheema",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/41/85680241.geojson
+++ b/data/856/802/41/85680241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065101,
-    "geom:area_square_m":804968725.554799,
+    "geom:area_square_m":804969191.114517,
     "geom:bbox":"30.114491,-0.455004,30.517219,-0.187026",
     "geom:latitude":-0.327319,
     "geom:longitude":30.326065,
@@ -156,14 +156,16 @@
         "gn:id":8030585,
         "gp:id":-20070414,
         "hasc:id":"UG.BH",
+        "iso:code":"UG-325",
         "iso:id":"UG-325",
         "wd:id":"Q4986330"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c07f1523fb0415616a8ed64b5331e43f",
+    "wof:geomhash":"1d86ab8cd936cb629b48a9371a077947",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -180,7 +182,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501846,
+    "wof:lastmodified":1695884916,
     "wof:name":"Buhweju",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/47/85680247.geojson
+++ b/data/856/802/47/85680247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.388144,
-    "geom:area_square_m":4794786520.662314,
+    "geom:area_square_m":4794786539.340186,
     "geom:bbox":"31.33775,2.217803,32.35975,2.837462",
     "geom:latitude":2.530242,
     "geom:longitude":31.840608,
@@ -214,14 +214,16 @@
         "fips:code":"UGH2",
         "gp:id":20070415,
         "hasc:id":"UG.NW",
+        "iso:code":"UG-329",
         "iso:id":"UG-329",
         "wd:id":"Q1028215"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3f12d820c837b4f30cacb78e6327a2f",
+    "wof:geomhash":"f5d791c9a843d21681bd1c57259a6396",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -238,7 +240,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690877029,
+    "wof:lastmodified":1695884916,
     "wof:name":"Nwoya",
     "wof:parent_id":85632625,
     "wof:placetype":"region",

--- a/data/856/802/51/85680251.geojson
+++ b/data/856/802/51/85680251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020591,
-    "geom:area_square_m":254573544.835183,
+    "geom:area_square_m":254573594.003646,
     "geom:bbox":"34.271047,0.96617,34.533896,1.118706",
     "geom:latitude":1.048337,
     "geom:longitude":34.396319,
@@ -177,15 +177,17 @@
         "gn:id":7056280,
         "gp:id":-20070433,
         "hasc:id":"UG.BA",
+        "iso:code":"UG-223",
         "iso:id":"UG-223",
         "unlc:id":"UG-223",
         "wd:id":"Q4985181"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7834cb35d886838b3417fb5647ce6669",
+    "wof:geomhash":"89dd4b7dbc7dd33e1970924e9112ab89",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +204,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1636501845,
+    "wof:lastmodified":1695884915,
     "wof:name":"Bududa",
     "wof:parent_id":85632625,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.